### PR TITLE
Fix bug when print_info parameter of nlsolve was not taken into account

### DIFF
--- a/fedoo/problem/non_linear.py
+++ b/fedoo/problem/non_linear.py
@@ -504,11 +504,12 @@ class _NonLinearBase:
             else:
                 if update_dt:
                     dt *= 0.25
-                    print(
-                        "NR failed to converge (err: {:.5f}) - reduce the time increment to {:.5f}".format(
-                            normRes, dt
+                    if self.print_info > 0:
+                        print(
+                            "NR failed to converge (err: {:.5f}) - reduce the time increment to {:.5f}".format(
+                                normRes, dt
+                            )
                         )
-                    )
 
                     if dt < dt_min:
                         raise NameError(


### PR DESCRIPTION
Nlsolve method is not taking into account print_info parameter when convergence is failed. For the futur it may be useful to use printing/logging levels to specify the kind of errors.