### PR TITLE
Add python-mumps support and factorization reuse

### DIFF
--- a/docs/Install.rst
+++ b/docs/Install.rst
@@ -28,8 +28,8 @@ In addition, the conda package also includes some recommended dependencies:
     * `PyVista <https://docs.pyvista.org/version/stable/>`_
       for results visualization and mesh utils.
 
-    * An efficient sparse matrix solver (pypardiso or petsc4py) depending
-      on the processor as described below.
+    * An efficient sparse matrix solver (pypardiso, python-mumps or
+      petsc4py) depending on the processor as described below.
 
 
 Full pip install
@@ -71,7 +71,7 @@ You can also install optional groups individually:
 
 .. code-block:: none
 
-    $ pip install fedoo[solver]      # fast sparse solver (pypardiso or umfpack)
+    $ pip install fedoo[solver]      # fast sparse solver (pypardiso, python-mumps, or umfpack)
     $ pip install fedoo[plot]        # matplotlib + pyvista
     $ pip install fedoo[simcoon]     # simcoon
     $ pip install fedoo[ipc]         # IPC contact (ipctk)
@@ -85,10 +85,17 @@ It is highly recommended to install a fast direct sparse matrix solver
 to improve performances:
 
     * `Pypardiso <https://pypi.org/project/pypardiso/>`_
-      for intel processors (binding to the pardiso solver)
+      for intel processors (binding to the pardiso solver).
+
+    * `python-mumps <https://pypi.org/project/python-mumps/>`_
+      standalone Python bindings for the MUMPS direct solver. Recommended
+      on arm64 (Apple Silicon, ARM Linux) where pypardiso is not available
+      and as a lighter alternative to PETSc when only direct solving is
+      needed.
 
     * `Petsc4Py <https://pypi.org/project/petsc4py/>`_
       mainly compatible with linux or macos including the MUMPS solver.
+      Use this if you need PETSc's iterative solvers or MPI parallelism.
 
     * `Scikit-umfpack <https://scikit-umfpack.github.io/scikit-umfpack/>`_
 

--- a/docs/Install.rst
+++ b/docs/Install.rst
@@ -71,7 +71,7 @@ You can also install optional groups individually:
 
 .. code-block:: none
 
-    $ pip install fedoo[solver]      # fast sparse solver (pypardiso, python-mumps, or umfpack)
+    $ pip install fedoo[solver]      # fast sparse solver (pypardiso or python-mumps)
     $ pip install fedoo[plot]        # matplotlib + pyvista
     $ pip install fedoo[simcoon]     # simcoon
     $ pip install fedoo[ipc]         # IPC contact (ipctk)
@@ -98,6 +98,11 @@ to improve performances:
       Use this if you need PETSc's iterative solvers or MPI parallelism.
 
     * `Scikit-umfpack <https://scikit-umfpack.github.io/scikit-umfpack/>`_
+      optional fallback to ``python-mumps``. Detected automatically if
+      installed, useful in very specific cases (e.g. very small problems,
+      or as a serial backup). Not included in ``[solver]`` extras because
+      its install can be tricky on some platforms; install it manually if
+      you need it.
 
 To be able to launch the fedoo viewer, the module 
 `pyvistaqt <https://qtdocs.pyvista.org/>`_ is also required.

--- a/fedoo/core/base.py
+++ b/fedoo/core/base.py
@@ -592,7 +592,10 @@ class ProblemBase:
 
         Backend is selected automatically (pypardiso > python-mumps > petsc),
         regardless of the solver previously set with :meth:`set_solver`. The
-        reuse path is direct LU only; iterative solvers are not supported.
+        reuse path is direct LU only; if an iterative solver was set with
+        :meth:`set_solver`, it is silently bypassed while reuse is enabled.
+        Disable reuse with ``set_reuse_factorization(False)`` to restore the
+        normal solver dispatch.
 
         Examples
         --------

--- a/fedoo/core/base.py
+++ b/fedoo/core/base.py
@@ -573,7 +573,8 @@ class ProblemBase:
         stiffness computation by perturbation, multiple load cases on a
         linear problem).
 
-        Requires `python-mumps` to be installed.
+        Requires one of `pypardiso`, `python-mumps` or `petsc4py` to be
+        installed (same backend priority as ``solver="direct"``).
 
         Parameters
         ----------
@@ -589,6 +590,10 @@ class ProblemBase:
         reduced system matrix (e.g. Dirichlet boundary conditions affecting
         the constraint reduction matrix).
 
+        Backend is selected automatically (pypardiso > python-mumps > petsc),
+        regardless of the solver previously set with :meth:`set_solver`. The
+        reuse path is direct LU only; iterative solvers are not supported.
+
         Examples
         --------
         >>> pb.set_reuse_factorization(True)
@@ -600,14 +605,18 @@ class ProblemBase:
         >>> pb.set_reuse_factorization(False)
         """
         if reuse:
-            if not USE_MUMPS:
+            if USE_PYPARDISO:
+                self._factor_context = _PypardisoFactor()
+            elif USE_MUMPS:
+                self._factor_context = _MumpsFactor()
+            elif USE_PETSC:
+                self._factor_context = _PetscFactor()
+            else:
                 raise RuntimeError(
-                    "Factorization reuse requires python-mumps. "
-                    'Install it with "pip install python-mumps".'
+                    "Factorization reuse requires pypardiso, python-mumps, "
+                    "or petsc4py. Install one of them, e.g. "
+                    '"pip install python-mumps".'
                 )
-            import mumps
-
-            self._factor_context = mumps.Context()
             self._factor_valid = False
         else:
             self._factor_context = None
@@ -784,3 +793,61 @@ def _solver_mumps(A, B, **kargs):
     import mumps
 
     return mumps.spsolve(A, B)
+
+
+# =============================================================
+# Factor-reuse adapters used by ProblemBase.set_reuse_factorization
+# All expose a uniform .factor(A) / .solve(B) interface.
+# =============================================================
+class _MumpsFactor:
+    def __init__(self):
+        import mumps
+
+        self._ctx = mumps.Context()
+
+    def factor(self, A):
+        self._ctx.factor(A)
+
+    def solve(self, B):
+        return self._ctx.solve(B)
+
+
+class _PypardisoFactor:
+    def __init__(self):
+        from pypardiso import PyPardisoSolver
+
+        self._solver = PyPardisoSolver()
+        self._A = None
+
+    def factor(self, A):
+        self._A = A
+        self._solver.factorize(A)
+
+    def solve(self, B):
+        return self._solver.solve(self._A, B)
+
+
+class _PetscFactor:
+    def __init__(self):
+        global PETSc
+
+        self._A_petsc = None
+        self._ksp = PETSc.KSP()
+        self._ksp.create()
+        self._ksp.setType("preonly")
+        pc = self._ksp.getPC()
+        pc.setType("lu")
+        pc.setFactorSolverType("mumps")
+
+    def factor(self, A):
+        self._A_petsc = PETSc.Mat().createAIJWithArrays(
+            A.shape, (A.indptr, A.indices, A.data)
+        )
+        self._ksp.setOperators(self._A_petsc)
+        self._ksp.setUp()  # triggers factorization
+
+    def solve(self, B):
+        B_petsc = PETSc.Vec().createWithArray(B)
+        x = self._A_petsc.createVecLeft()
+        self._ksp.solve(B_petsc, x)
+        return x.getArray().copy()

--- a/fedoo/core/base.py
+++ b/fedoo/core/base.py
@@ -15,6 +15,7 @@ try:
     from pypardiso import spsolve
 
     USE_PYPARDISO = True
+    USE_MUMPS = False
     USE_UMFPACK = False
     USE_PETSC = False  # only for the direct mumps solver
 except ModuleNotFoundError:
@@ -22,40 +23,49 @@ except ModuleNotFoundError:
 
 if not USE_PYPARDISO:
     try:
+        import mumps
+
+        USE_MUMPS = True
+        USE_UMFPACK = False
+        USE_PETSC = False
+    except ModuleNotFoundError:
+        USE_MUMPS = False
+
+if not USE_PYPARDISO and not USE_MUMPS:
+    try:
         import petsc4py
         import sys
 
         petsc4py.init(sys.argv)
         from petsc4py import PETSc
 
-        USE_PYPARDISO = False
         USE_UMFPACK = False
         USE_PETSC = True
     except ModuleNotFoundError:
         USE_PETSC = False
 
-if not USE_PYPARDISO and not USE_PETSC:
+if not USE_PYPARDISO and not USE_MUMPS and not USE_PETSC:
     try:
         from scikits.umfpack import spsolve
 
         scipy.sparse.linalg.use_solver(assumeSortedIndicesbool=True)
-        USE_PYPARDISO = False
         USE_UMFPACK = True
-        USE_PETSC = False
     except ModuleNotFoundError:
         USE_UMFPACK = False
 
-if not USE_PYPARDISO and not USE_PETSC and not USE_UMFPACK:
+if not USE_PYPARDISO and not USE_MUMPS and not USE_PETSC and not USE_UMFPACK:
     warnings.warn(
         "WARNING: no fast direct sparse solver has been found. "
-        "Consider installing pypardiso, petsc, or scikit-umfpack to improve "
-        "computation performance"
+        "Consider installing pypardiso, python-mumps, petsc, or scikit-umfpack "
+        "to improve computation performance"
     )
 
 
 def _reload_external_solvers(config_dict):
     if config_dict["USE_PYPARDISO"]:
         from pypardiso import spsolve
+    if config_dict["USE_MUMPS"]:
+        import mumps  # noqa: F401
     if config_dict["USE_PETSC"]:
         global PETSc
 
@@ -285,6 +295,8 @@ class ProblemBase:
         assert isinstance(name, str), "A name must be a string"
         self.__name = name
         self.__solver = ["direct"]
+        self._factor_context = None
+        self._factor_valid = False
         self.bc = ListBC(
             name=self.name + "_bc"
         )  # list containing boundary contidions associated to the problem
@@ -389,16 +401,20 @@ class ProblemBase:
             Type of solver.
             The possible choice are :
             * 'direct': direct solver. If pypardiso is installed, the
-              pypardiso solver is used. Else, if petsc is installed, the mumps
-              solver is used. If not, the function scipy.sparse.linalg.spsolve
-              is used. If sckikit-umfpack is installed, scipy will use the
-              umfpack solver which is significantly more efficient than the
-              base scipy solver.
+              pypardiso solver is used. Else, if python-mumps is installed,
+              the standalone MUMPS solver is used. Else, if petsc is installed,
+              the mumps solver from petsc is used. If not, the function
+              scipy.sparse.linalg.spsolve is used. If scikit-umfpack is
+              installed, scipy will use the umfpack solver which is
+              significantly more efficient than the base scipy solver.
             * 'cg', 'bicg', 'bicgstab','minres','gmres', 'lgmres' or 'gcrotmk'
               using the corresponding iterative method from
               scipy.sparse.linalg. For instance, 'cg' is the conjugate
               gradient based on the function scipy.sparse.linalg.cg.
             * 'pardiso': force the use of the pypardiso solver
+            * 'mumps': force the use of the standalone MUMPS solver
+              (python-mumps must be installed). This is the recommended direct
+              solver on arm64 platforms where pypardiso is not available.
             * 'direct_scipy': force the use of the direct scipy solver
               (umfpack if installed)
             * 'petsc': use the petsc methods (iterative or direct). petsc4py
@@ -461,23 +477,16 @@ class ProblemBase:
             if solver == "direct":
                 if USE_PYPARDISO:
                     solver_func = spsolve
-                    # print(
-                    #     f"Problem {self.name} : direct solver : PYPARDISO solver has been utilized"
-                    # )
+                elif USE_MUMPS:
+                    solver_func = _solver_mumps
                 elif USE_PETSC:
                     global PETSc
                     solver_func = _solver_petsc
                     kargs["solver_type"] = "preonly"
                     kargs["pc_type"] = "lu"
                     kargs["pc_factor_mat_solver_type"] = "mumps"
-                    # print(
-                    #     f"Problem {self.name} : direct solver : MUMPS solver from the PETSC lib "
-                    # )
                 else:
                     solver_func = sparse.linalg.spsolve
-                    # print(
-                    #     f"Problem {self.name} : direct solver : Scipy direct solver has been utilized : if SCIPY-UMFPACK is installed, it will be used"
-                    # )
             elif solver in [
                 "cg",
                 "bicg",
@@ -514,6 +523,13 @@ class ProblemBase:
                     raise NameError(
                         'pypardiso not installed. Use "pip install pypardiso".'
                     )
+            elif solver == "mumps":
+                if USE_MUMPS:
+                    solver_func = _solver_mumps
+                else:
+                    raise NameError(
+                        'python-mumps not installed. Use "pip install python-mumps".'
+                    )
             elif solver == "direct_scipy":
                 solver_func = sparse.linalg.spsolve
             else:
@@ -524,6 +540,12 @@ class ProblemBase:
         self.__solver = [solver, solver_func, kargs, return_info, precond]
 
     def _solve(self, A, B):
+        if self._factor_context is not None:
+            if not self._factor_valid:
+                self._factor_context.factor(A)
+                self._factor_valid = True
+            return self._factor_context.solve(B)
+
         kargs = self.__solver[2]
         if self.__solver[3]:  # return_info = True
             precond = self.__solver[4]
@@ -540,6 +562,64 @@ class ProblemBase:
             return res
         else:
             return self.__solver[1](A, B, **kargs)
+
+    def set_reuse_factorization(self, reuse: bool = True):
+        """Enable or disable factorization reuse for repeated solves.
+
+        When enabled, the system matrix is factorized on the first call to
+        :meth:`solve`, then subsequent calls reuse the factorization and only
+        perform back-substitution. This is useful when the matrix does not
+        change between solves but the right-hand side does (e.g. tangent
+        stiffness computation by perturbation, multiple load cases on a
+        linear problem).
+
+        Requires `python-mumps` to be installed.
+
+        Parameters
+        ----------
+        reuse: bool, default=True
+            If True, enable factorization reuse. If False, disable it and
+            release the cached factorization.
+
+        Notes
+        -----
+        The factorization is automatically invalidated when :meth:`set_A` is
+        called. The user is responsible for calling
+        :meth:`invalidate_factorization` if anything else modifies the
+        reduced system matrix (e.g. Dirichlet boundary conditions affecting
+        the constraint reduction matrix).
+
+        Examples
+        --------
+        >>> pb.set_reuse_factorization(True)
+        >>> for B in load_cases:
+        ...     pb.set_B(B)
+        ...     pb.apply_boundary_conditions()
+        ...     pb.solve()
+        ...     # ... read result
+        >>> pb.set_reuse_factorization(False)
+        """
+        if reuse:
+            if not USE_MUMPS:
+                raise RuntimeError(
+                    "Factorization reuse requires python-mumps. "
+                    'Install it with "pip install python-mumps".'
+                )
+            import mumps
+
+            self._factor_context = mumps.Context()
+            self._factor_valid = False
+        else:
+            self._factor_context = None
+            self._factor_valid = False
+
+    def invalidate_factorization(self):
+        """Invalidate any cached factorization.
+
+        Call this after modifying the system matrix when factorization reuse
+        is enabled. :meth:`set_A` calls it automatically.
+        """
+        self._factor_valid = False
 
     @staticmethod
     def get_all():
@@ -698,3 +778,9 @@ def _solver_petsc(
     elif isinstance(A, (sparse.csc_array, sparse.csc_matrix)):
         ksp.solveTranspose(B_petsc, res)
     return res
+
+
+def _solver_mumps(A, B, **kargs):
+    import mumps
+
+    return mumps.spsolve(A, B)

--- a/fedoo/core/base.py
+++ b/fedoo/core/base.py
@@ -56,7 +56,7 @@ if not USE_PYPARDISO and not USE_MUMPS and not USE_PETSC:
 if not USE_PYPARDISO and not USE_MUMPS and not USE_PETSC and not USE_UMFPACK:
     warnings.warn(
         "WARNING: no fast direct sparse solver has been found. "
-        "Consider installing pypardiso, python-mumps, petsc, or scikit-umfpack "
+        "Consider installing pypardiso (Intel) or python-mumps (any platform) "
         "to improve computation performance"
     )
 

--- a/fedoo/core/problem.py
+++ b/fedoo/core/problem.py
@@ -252,6 +252,7 @@ class Problem(ProblemBase):
 
     def set_A(self, A):
         self.__A = A
+        self.invalidate_factorization()
 
     def get_A(self):
         return self.__A

--- a/fedoo/core/problem.py
+++ b/fedoo/core/problem.py
@@ -254,6 +254,20 @@ class Problem(ProblemBase):
         self.__A = A
         self.invalidate_factorization()
 
+    def _set_A_from_assembly(self, A):
+        """Internal: install the assembly's matrix without invalidating
+        the cached factorization when the matrix object is unchanged.
+
+        Used by Problem subclasses (Linear, NonLinear, …) to refresh A
+        from ``assembly.get_global_matrix()``. If the assembly returned
+        the same object (e.g. ``assemble_global_mat("none")`` was a
+        no-op), the cached factorization stays valid.
+        """
+        if A is self.__A:
+            return
+        self.__A = A
+        self.invalidate_factorization()
+
     def get_A(self):
         return self.__A
 

--- a/fedoo/homogen/tangent_stiffness.py
+++ b/fedoo/homogen/tangent_stiffness.py
@@ -104,14 +104,15 @@ def get_tangent_stiffness(pb=None, meshperio=True, **kargs):
 
     # Reuse factorization across perturbations: A and the constraint
     # reduction matrix _MatCB are constant in this loop (only Neumann BCs
-    # on global E_xx/yy/.. dofs change, affecting only B). With python-mumps,
-    # this gives a 4-6x speedup on tangent stiffness computation.
+    # on global E_xx/yy/.. dofs change, affecting only B). Gives a ~4-6x
+    # speedup on tangent stiffness computation when a direct backend
+    # (pypardiso, python-mumps or petsc) is available.
     reuse_factor = False
     try:
         pb_post_tt.set_reuse_factorization(True)
         reuse_factor = True
     except RuntimeError:
-        pass  # python-mumps not installed, fall back to per-iteration solves
+        pass  # no direct backend available, fall back to per-iteration solves
 
     for i in range(len(BC_perturb)):
         pb_post_tt.bc.add(

--- a/fedoo/homogen/tangent_stiffness.py
+++ b/fedoo/homogen/tangent_stiffness.py
@@ -104,9 +104,9 @@ def get_tangent_stiffness(pb=None, meshperio=True, **kargs):
 
     # Reuse factorization across perturbations: A and the constraint
     # reduction matrix _MatCB are constant in this loop (only Neumann BCs
-    # on global E_xx/yy/.. dofs change, affecting only B). Gives a ~4-6x
-    # speedup on tangent stiffness computation when a direct backend
-    # (pypardiso, python-mumps or petsc) is available.
+    # on global E_xx/yy/.. dofs change, affecting only B). Avoids re-
+    # factorizing on each perturbation when a direct backend (pypardiso,
+    # python-mumps or petsc) is available.
     reuse_factor = False
     try:
         pb_post_tt.set_reuse_factorization(True)

--- a/fedoo/homogen/tangent_stiffness.py
+++ b/fedoo/homogen/tangent_stiffness.py
@@ -102,6 +102,17 @@ def get_tangent_stiffness(pb=None, meshperio=True, **kargs):
     # typeBC = 'Dirichlet' #doesn't work with meshperio = False
     typeBC = "Neumann"
 
+    # Reuse factorization across perturbations: A and the constraint
+    # reduction matrix _MatCB are constant in this loop (only Neumann BCs
+    # on global E_xx/yy/.. dofs change, affecting only B). With python-mumps,
+    # this gives a 4-6x speedup on tangent stiffness computation.
+    reuse_factor = False
+    try:
+        pb_post_tt.set_reuse_factorization(True)
+        reuse_factor = True
+    except RuntimeError:
+        pass  # python-mumps not installed, fall back to per-iteration solves
+
     for i in range(len(BC_perturb)):
         pb_post_tt.bc.add(
             typeBC,
@@ -188,6 +199,9 @@ def get_tangent_stiffness(pb=None, meshperio=True, **kargs):
                     ]
                 )
             )
+
+    if reuse_factor:
+        pb_post_tt.set_reuse_factorization(False)
 
     volume = mesh.bounding_box.volume
     if typeBC == "Neumann":

--- a/fedoo/problem/linear.py
+++ b/fedoo/problem/linear.py
@@ -68,19 +68,15 @@ class _LinearBase:
         Update the problem with the new assembled global matrix and global vector
         """
         out_values = self.__assembly.update(self, compute)
-        # Skip set_A / set_D when nothing was reassembled — re-setting A
-        # would invalidate any cached factorization (set_reuse_factorization)
-        # for no reason, since assemble_global_mat("none") is a no-op.
-        if compute != "none":
-            self.set_A(self.__assembly.get_global_matrix())
-            self.set_D(self.__assembly.get_global_vector())
+        self._set_A_from_assembly(self.__assembly.get_global_matrix())
+        self.set_D(self.__assembly.get_global_vector())
         return out_values
 
     def solve(self, **kargs):
         # Solve and update weakform (compute stress for instance) without updating global matrix
         # to avoid update weakform, use updateWF = True
         updateWF = kargs.pop("updateWF", True)
-        self.set_A(self.__assembly.get_global_matrix())
+        self._set_A_from_assembly(self.__assembly.get_global_matrix())
         self.set_D(self.__assembly.get_global_vector())
         self.init_bc_start_value()
         self.apply_boundary_conditions()

--- a/fedoo/problem/linear.py
+++ b/fedoo/problem/linear.py
@@ -68,8 +68,12 @@ class _LinearBase:
         Update the problem with the new assembled global matrix and global vector
         """
         out_values = self.__assembly.update(self, compute)
-        self.set_A(self.__assembly.get_global_matrix())
-        self.set_D(self.__assembly.get_global_vector())
+        # Skip set_A / set_D when nothing was reassembled — re-setting A
+        # would invalidate any cached factorization (set_reuse_factorization)
+        # for no reason, since assemble_global_mat("none") is a no-op.
+        if compute != "none":
+            self.set_A(self.__assembly.get_global_matrix())
+            self.set_D(self.__assembly.get_global_vector())
         return out_values
 
     def solve(self, **kargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fedoo"
-version = "0.8.1"
+version = "0.8.2"
 authors = [
     {name = "3MAH", email = 'set3mah@gmail.com'},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ ipc = ['ipctk']
 solver = [
     'pypardiso ; platform_machine!="arm64" and platform_machine!="aarch64"',
     'python-mumps ; platform_machine=="arm64" or platform_machine=="aarch64"',
-    'scikit-umfpack ; platform_machine=="arm64" or platform_machine=="aarch64"'
 ]
 plot = [
     'matplotlib',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ all = ['fedoo[solver,plot,test,ipc]']
 ipc = ['ipctk']
 solver = [
     'pypardiso ; platform_machine!="arm64" and platform_machine!="aarch64"',
+    'python-mumps ; platform_machine=="arm64" or platform_machine=="aarch64"',
     'scikit-umfpack ; platform_machine=="arm64" or platform_machine=="aarch64"'
 ]
 plot = [

--- a/tests/test_factor_reuse.py
+++ b/tests/test_factor_reuse.py
@@ -1,0 +1,101 @@
+"""Tests for the factorization reuse mechanism."""
+
+import numpy as np
+import pytest
+
+import fedoo as fd
+from fedoo.core.base import USE_MUMPS, USE_PETSC, USE_PYPARDISO
+
+
+HAS_DIRECT_BACKEND = USE_PYPARDISO or USE_MUMPS or USE_PETSC
+
+
+def _build_plate_problem():
+    fd.ModelingSpace("2Dstress")
+    fd.mesh.hole_plate_mesh(
+        nr=11,
+        nt=11,
+        length=100,
+        height=100,
+        radius=20,
+        elm_type="quad4",
+        name="Domain",
+    )
+    fd.constitutivelaw.ElasticIsotrop(2e5, 0.3, name="ElasticLaw")
+    fd.weakform.StressEquilibrium("ElasticLaw", name="WeakForm")
+    fd.Assembly.create("WeakForm", "Domain", name="Assembly", MeshChange=True)
+    pb = fd.problem.Linear("Assembly")
+
+    mesh = fd.Mesh["Domain"]
+    left = mesh.find_nodes("X", mesh.bounding_box.xmin)
+    right = mesh.find_nodes("X", mesh.bounding_box.xmax)
+    bottom = mesh.find_nodes("Y", mesh.bounding_box.ymin)
+
+    pb.bc.add("Dirichlet", left, "DispX", 0)
+    pb.bc.add("Dirichlet", bottom, "DispY", 0)
+    pb.bc.add("Dirichlet", right, "DispX", 0.1)
+    pb.apply_boundary_conditions()
+    return pb
+
+
+@pytest.mark.skipif(
+    not HAS_DIRECT_BACKEND,
+    reason="No direct backend (pypardiso, python-mumps or petsc4py) installed",
+)
+def test_reuse_factorization_matches_baseline():
+    """Solving with factor reuse must give the same result as without."""
+    # Baseline: standard solve
+    pb_ref = _build_plate_problem()
+    pb_ref.solve()
+    U_ref = pb_ref.get_disp().copy()
+
+    # With factor reuse
+    pb = _build_plate_problem()
+    pb.set_reuse_factorization(True)
+    pb.solve()
+    U = pb.get_disp()
+
+    assert np.allclose(U, U_ref, atol=1e-12)
+
+
+@pytest.mark.skipif(
+    not HAS_DIRECT_BACKEND,
+    reason="No direct backend (pypardiso, python-mumps or petsc4py) installed",
+)
+def test_reuse_factorization_repeated_solves():
+    """Multiple solves with same A and reuse must all match the baseline."""
+    pb_ref = _build_plate_problem()
+    pb_ref.solve()
+    U_ref = pb_ref.get_disp().copy()
+
+    pb = _build_plate_problem()
+    pb.set_reuse_factorization(True)
+    for _ in range(3):
+        pb.solve()
+        assert np.allclose(pb.get_disp(), U_ref, atol=1e-12)
+    pb.set_reuse_factorization(False)
+
+
+def test_set_reuse_factorization_no_backend():
+    """Without a direct backend, set_reuse_factorization must raise."""
+    if HAS_DIRECT_BACKEND:
+        pytest.skip("a direct backend is available, can't test the no-backend path")
+
+    pb = _build_plate_problem()
+    with pytest.raises(RuntimeError, match="pypardiso|python-mumps|petsc4py"):
+        pb.set_reuse_factorization(True)
+
+
+def test_invalidate_factorization_via_set_A():
+    """set_A must invalidate the cached factorization."""
+    if not HAS_DIRECT_BACKEND:
+        pytest.skip("requires a direct backend")
+
+    pb = _build_plate_problem()
+    pb.set_reuse_factorization(True)
+    pb.solve()  # factorizes
+    assert pb._factor_valid is True
+
+    # touching A must invalidate
+    pb.set_A(pb.get_A())
+    assert pb._factor_valid is False


### PR DESCRIPTION
Introduce optional python-mumps solver support and reuseable factorization to speed repeated solves.

- Detect and prefer python-mumps when available (base solver detection logic updated). Add a thin _solver_mumps wrapper and a new 'mumps' solver option.
- Add set_reuse_factorization and invalidate_factorization on ProblemBase to cache a mumps.Context factorization for repeated solves and use it in _solve. Ensure cached factorization is invalidated when set_A is called.
- Update tangent stiffness routine to attempt enabling factorization reuse for perturbation loops (fall back if python-mumps is unavailable).
- Update docs (Install.rst) to mention python-mumps as a recommended direct solver (esp. for arm64/M1) and explain use cases vs. PETSc/pypardiso.
- Add python-mumps to pyproject dependencies for arm64/aarch64 platform.

These changes improve performance for workflows that reuse the same matrix across multiple RHS (e.g. tangent stiffness perturbations) and provide a recommended lighter alternative to PETSc on platforms where pypardiso is not available.