### PR TITLE
Use python-mumps Context API in solver

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,8 @@ dependencies:
   - scipy
   - pypardiso # [x86 or x86_64]
   - scikit-umfpack # [(not x86) and (not x86_64)]
+  - python-mumps  # exercises _solver_mumps default path and the
+                  # _MumpsFactor reuse adapter, regardless of platform
   - vtk>=9.2
   - pyvista>=0.39
   - simcoon>=1.11.0

--- a/fedoo/core/base.py
+++ b/fedoo/core/base.py
@@ -793,9 +793,15 @@ def _solver_petsc(
 
 
 def _solver_mumps(A, B, **kargs):
+    # python-mumps exposes a Context-based API only; there is no
+    # top-level spsolve. For repeated solves on the same A, use
+    # `Problem.set_reuse_factorization(True)` to keep the Context alive
+    # across calls (see _MumpsFactor).
     import mumps
 
-    return mumps.spsolve(A, B)
+    ctx = mumps.Context()
+    ctx.factor(A)
+    return ctx.solve(B)
 
 
 # =============================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fedoo"
-version = "0.8.2"
+version = "0.8.3"
 authors = [
     {name = "3MAH", email = 'set3mah@gmail.com'},
 ]

--- a/tests/test_factor_reuse.py
+++ b/tests/test_factor_reuse.py
@@ -99,3 +99,31 @@ def test_invalidate_factorization_via_set_A():
     # touching A must invalidate
     pb.set_A(pb.get_A())
     assert pb._factor_valid is False
+
+
+def test_solver_mumps_default_path():
+    """``_solver_mumps`` must use the python-mumps Context API.
+
+    Regression test for a latent bug where the function called
+    ``mumps.spsolve`` which does not exist in the python-mumps package.
+    The bug went unnoticed in CI because CI installs pypardiso (x86),
+    so the mumps default path was never exercised. Triggers on any
+    arm64 environment where python-mumps is the auto-selected backend.
+    """
+    try:
+        import mumps  # noqa: F401
+    except ImportError:
+        pytest.skip("python-mumps not installed")
+
+    import scipy.sparse as sp
+    from fedoo.core.base import _solver_mumps
+
+    # Small symmetric positive-definite tridiagonal system: A x = b
+    n = 8
+    main = 2.0 * np.ones(n)
+    off = -1.0 * np.ones(n - 1)
+    A = sp.diags([off, main, off], offsets=[-1, 0, 1], format="csr")
+    b = np.arange(1.0, n + 1.0)
+
+    x = _solver_mumps(A, b)
+    assert np.allclose(A @ x, b, atol=1e-10)


### PR DESCRIPTION
Replace a nonexistent mumps.spsolve call with the Context-based API: create a mumps.Context(), factor the matrix and solve. Add a comment about keeping the Context alive for repeated solves (Problem.set_reuse_factorization(True)).

Add a regression test (test_solver_mumps_default_path) that skips if python-mumps is not installed and verifies the Context-based solver correctly solves a small SPD tridiagonal system. This fixes a latent bug that went unnoticed in CI (pypardiso present) but surfaced on environments where python-mumps is the selected backend.