### PR TITLE
Add nodal gradient/Hessian recovery utilities

### DIFF
--- a/examples/adaptive/hessian_recovery.py
+++ b/examples/adaptive/hessian_recovery.py
@@ -1,0 +1,69 @@
+"""
+Nodal Hessian recovery on a fedoo mesh
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Compute the recovered nodal gradient and Hessian of an analytic scalar
+field on a 2D mesh using ``fedoo.recover_gradient`` and
+``fedoo.recover_hessian``. The output is written to a vtk file so you can
+inspect it in ParaView.
+
+Pair with ``mmgpy.metrics.create_metric_from_hessian`` (and
+``fedoo.to_upper_diagonal`` to get mmg's row-major upper-triangular
+packing) to drive anisotropic adaptive remeshing.
+"""
+
+import numpy as np
+import fedoo as fd
+
+###############################################################################
+# Build a 2D mesh and an analytic scalar field with a known closed-form Hessian.
+mesh = fd.mesh.rectangle_mesh(nx=51, ny=51, elm_type="tri3")
+x, y = mesh.nodes.T
+
+# f(x, y) = sin(2*pi*x) * sin(2*pi*y)
+# d2f/dx2 = -4*pi^2 * sin(2*pi*x) * sin(2*pi*y)
+# d2f/dy2 = -4*pi^2 * sin(2*pi*x) * sin(2*pi*y)
+# d2f/dxdy =  4*pi^2 * cos(2*pi*x) * cos(2*pi*y)
+field = np.sin(2 * np.pi * x) * np.sin(2 * np.pi * y)
+
+###############################################################################
+# Recover gradient and Hessian. Both calls reuse fedoo's cached
+# GP-to-Node projection matrix and shape-derivative tables - everything is
+# vectorized, no per-vertex Python loop.
+g = fd.recover_gradient(mesh, field)  # (n_nodes, 2)
+H = fd.recover_hessian(mesh, field)  # (n_nodes, 2, 2)
+
+# Compare against the analytic Hessian on interior nodes.
+k = (2 * np.pi) ** 2
+H_xx_exact = -k * np.sin(2 * np.pi * x) * np.sin(2 * np.pi * y)
+H_xy_exact = +k * np.cos(2 * np.pi * x) * np.cos(2 * np.pi * y)
+
+interior = (x > 0.1) & (x < 0.9) & (y > 0.1) & (y < 0.9)
+err_xx = np.abs(H[interior, 0, 0] - H_xx_exact[interior]).max()
+err_xy = np.abs(H[interior, 0, 1] - H_xy_exact[interior]).max()
+print(f"max |H_xx - exact| (interior) = {err_xx:.3e}")
+print(f"max |H_xy - exact| (interior) = {err_xy:.3e}")
+
+###############################################################################
+# Save a vtk file with the recovered fields for visualisation in ParaView.
+ds = fd.DataSet(
+    mesh,
+    data={
+        "field": field,
+        "grad": g.T,  # (2, n_nodes) for fedoo's vector layout
+        "H_xx": H[:, 0, 0],
+        "H_yy": H[:, 1, 1],
+        "H_xy": H[:, 0, 1],
+    },
+    data_type="node",
+)
+ds.save("hessian_recovery.vtk")
+print("Wrote hessian_recovery.vtk")
+
+###############################################################################
+# To drive an mmg adaptive remesh, pack the Hessian into mmg's
+# row-major upper-triangular layout and feed it to
+# ``mmgpy.metrics.create_metric_from_hessian``::
+#
+#     metric = fd.to_upper_diagonal(H)        # (n_nodes, 3) for 2D
+#     # mmgpy.metrics.create_metric_from_hessian(metric, target_error=1e-3, ...)

--- a/fedoo/__init__.py
+++ b/fedoo/__init__.py
@@ -24,6 +24,12 @@ from .core import (
     WeakFormSum,
     read_data,
 )
+from .util.recovery import (
+    recover_gradient,
+    recover_hessian,
+    to_upper_diagonal,
+    to_voigt,
+)
 
 try:
     from .util.viewer import viewer

--- a/fedoo/core/assembly.py
+++ b/fedoo/core/assembly.py
@@ -1267,11 +1267,15 @@ class Assembly(AssemblyBase):
         res = self.get_gp_results(operator, U)
         return self.mesh._get_gausspoint2node_mat(self.n_elm_gp) @ res
 
-    def convert_data(self, data, convert_from=None, convert_to="GaussPoint"):
+    def convert_data(
+        self, data, convert_from=None, convert_to="GaussPoint", method=None
+    ):
         if isinstance(data, (StrainTensorList, StressTensorList)):
-            return data.convert(self, convert_from, convert_to)
+            return data.convert(self, convert_from, convert_to, method)
 
-        return self.mesh.convert_data(data, convert_from, convert_to, self.n_elm_gp)
+        return self.mesh.convert_data(
+            data, convert_from, convert_to, self.n_elm_gp, method
+        )
 
     def integrate_field(self, field, type_field=None):
         return self.mesh.integrate_field(field, type_field, self.n_elm_gp)
@@ -1286,12 +1290,14 @@ class Assembly(AssemblyBase):
                 new_mesh = copy(self.mesh)
                 new_mesh.nodes = new_crd
                 new_mesh._saved_gaussian_quadrature_mat = {}
+                new_mesh._saved_gausspoint2node_l2 = {}
                 new_assembly = copy(self)
                 new_assembly.mesh = new_mesh
                 self.current = new_assembly
             else:
                 self.current.mesh.nodes = new_crd
                 self.current.mesh._saved_gaussian_quadrature_mat = {}
+                self.current.mesh._saved_gausspoint2node_l2 = {}
 
                 if self.current.mesh in self._saved_change_of_basis_mat:
                     del self._saved_change_of_basis_mat[self.current.mesh]

--- a/fedoo/core/mesh.py
+++ b/fedoo/core/mesh.py
@@ -1223,7 +1223,8 @@ class Mesh(MeshBase):
                 raise ValueError(
                     "L2 GaussPoint to Node conversion failed because the "
                     "projection mass matrix is singular. Try a higher number "
-                    "of Gauss points per element or use method='mean'."
+                    "of Gauss points per element or use method='mean' or "
+                    "method='spr'."
                 ) from exc
             self._saved_gausspoint2node_l2[n_elm_gp] = (solve, rhs)
         return self._saved_gausspoint2node_l2[n_elm_gp]
@@ -1238,17 +1239,92 @@ class Mesh(MeshBase):
             method = "mean"
         else:
             method = method.lower()
-            if method not in ["mean", "l2"]:
+            if method not in ["mean", "l2", "spr"]:
                 raise ValueError(
                     "unknown GaussPoint to Node conversion method "
-                    f"'{method}'. Use 'mean' or 'l2'."
+                    f"'{method}'. Use 'mean', 'l2' or 'spr'."
                 )
 
         if method == "mean":
             return self._get_gausspoint2node_mat(n_elm_gp) @ data
+        if method == "spr":
+            return self._gausspoint_to_node_spr(data, n_elm_gp)
 
         solve, rhs = self._get_gausspoint2node_l2(n_elm_gp)
         return solve(rhs @ data)
+
+    def _gausspoint_to_node_spr(
+        self,
+        data: np.ndarray,
+        n_elm_gp: int | None = None,
+    ) -> np.ndarray:
+        """Recover nodal values from Gauss-point values by linear SPR patches."""
+        if n_elm_gp is None:
+            n_elm_gp = get_default_n_gp(self.elm_type)
+
+        data_is_1d = data.ndim == 1
+        if data_is_1d:
+            data = data.reshape(-1, 1)
+
+        gp_coordinates = self.gausspoint_coordinates(n_elm_gp)
+        element_ids = np.arange(self.n_elements).reshape(-1, 1, 1)
+        gp_ids = np.arange(n_elm_gp).reshape(1, 1, -1)
+        patch_node_ids = np.broadcast_to(
+            self.elements[:, :, None],
+            (self.n_elements, self.n_elm_nodes, n_elm_gp),
+        ).reshape(-1)
+        patch_gp_ids = np.broadcast_to(
+            element_ids + gp_ids * self.n_elements,
+            (self.n_elements, self.n_elm_nodes, n_elm_gp),
+        ).reshape(-1)
+
+        shifted_coordinates = (
+            gp_coordinates[patch_gp_ids] - self.nodes[patch_node_ids, : self.ndim]
+        )
+        patch_scale = np.zeros(self.n_nodes)
+        np.maximum.at(
+            patch_scale,
+            patch_node_ids,
+            np.linalg.norm(shifted_coordinates, axis=1),
+        )
+        nonzero_scale = patch_scale[patch_node_ids] > 0
+        shifted_coordinates[nonzero_scale] /= patch_scale[patch_node_ids][
+            nonzero_scale
+        ].reshape(-1, 1)
+
+        design_matrix = np.column_stack(
+            (np.ones(len(patch_node_ids)), shifted_coordinates)
+        )
+        n_terms = design_matrix.shape[1]
+        n_components = data.shape[1]
+        normal_matrix = np.zeros((self.n_nodes, n_terms, n_terms))
+        rhs = np.zeros((self.n_nodes, n_terms, n_components))
+        np.add.at(
+            normal_matrix,
+            patch_node_ids,
+            design_matrix[:, :, None] * design_matrix[:, None, :],
+        )
+        np.add.at(
+            rhs,
+            patch_node_ids,
+            design_matrix[:, :, None] * data[patch_gp_ids, None, :],
+        )
+
+        node_data = (np.linalg.pinv(normal_matrix, rcond=1e-12) @ rhs)[:, 0, :]
+        patch_counts = np.bincount(
+            patch_node_ids, minlength=self.n_nodes
+        ).reshape(-1, 1)
+        patch_sum = np.zeros((self.n_nodes, n_components), dtype=node_data.dtype)
+        np.add.at(patch_sum, patch_node_ids, data[patch_gp_ids])
+        low_rank = np.linalg.matrix_rank(normal_matrix) < 2
+        has_patch = patch_counts[:, 0] > 0
+        node_data[low_rank & has_patch] = (
+            patch_sum[low_rank & has_patch] / patch_counts[low_rank & has_patch]
+        )
+
+        if data_is_1d:
+            return node_data.reshape(-1)
+        return node_data
 
     def _get_node2gausspoint_mat(self, n_elm_gp=None):
         if n_elm_gp is None:
@@ -1329,11 +1405,12 @@ class Mesh(MeshBase):
             inferred from the last axis length.
         n_elm_gp : int, optional
             Number of Gauss points per element.
-        method : {'mean', 'l2'}, optional
+        method : {'mean', 'l2', 'spr'}, optional
             Method used when converting Gauss-point values to nodes. ``'mean'``
             keeps the historical element-wise extrapolation followed by nodal
             averaging. ``'l2'`` performs a global L2 projection using fedoo's
-            node-to-Gauss-point interpolation and quadrature matrices.
+            node-to-Gauss-point interpolation and quadrature matrices. ``'spr'``
+            performs a linear Superconvergent Patch Recovery around each node.
         """
         if np.isscalar(data):
             return data

--- a/fedoo/core/mesh.py
+++ b/fedoo/core/mesh.py
@@ -1217,6 +1217,13 @@ class Mesh(MeshBase):
             quadrature = self._get_gaussian_quadrature_mat(n_elm_gp)
             mass = node2gp.T @ quadrature @ node2gp
             rhs = node2gp.T @ quadrature
+            if node2gp.shape[0] < node2gp.shape[1]:
+                raise ValueError(
+                    "L2 GaussPoint to Node conversion failed because the "
+                    "projection mass matrix is singular. Try a higher number "
+                    "of Gauss points per element or use method='mean' or "
+                    "method='spr'."
+                )
             try:
                 solve = linalg.factorized(mass.tocsc())
             except RuntimeError as exc:
@@ -1251,7 +1258,12 @@ class Mesh(MeshBase):
             return self._gausspoint_to_node_spr(data, n_elm_gp)
 
         solve, rhs = self._get_gausspoint2node_l2(n_elm_gp)
-        return solve(rhs @ data)
+        rhs_data = rhs @ data
+        if rhs_data.ndim == 1:
+            return solve(rhs_data)
+        return np.column_stack(
+            [solve(rhs_data[:, i]) for i in range(rhs_data.shape[1])]
+        )
 
     def _gausspoint_to_node_spr(
         self,

--- a/fedoo/core/mesh.py
+++ b/fedoo/core/mesh.py
@@ -1311,9 +1311,9 @@ class Mesh(MeshBase):
         )
 
         node_data = (np.linalg.pinv(normal_matrix, rcond=1e-12) @ rhs)[:, 0, :]
-        patch_counts = np.bincount(
-            patch_node_ids, minlength=self.n_nodes
-        ).reshape(-1, 1)
+        patch_counts = np.bincount(patch_node_ids, minlength=self.n_nodes).reshape(
+            -1, 1
+        )
         patch_sum = np.zeros((self.n_nodes, n_components), dtype=node_data.dtype)
         np.add.at(patch_sum, patch_node_ids, data[patch_gp_ids])
         low_rank = np.linalg.matrix_rank(normal_matrix) < 2

--- a/fedoo/core/mesh.py
+++ b/fedoo/core/mesh.py
@@ -123,6 +123,7 @@ class Mesh(MeshBase):
             self.crd_name = ("X", "Y", "Z")
 
         self._saved_gausspoint2node_mat = {}
+        self._saved_gausspoint2node_l2 = {}
         self._saved_node2gausspoint_mat = {}
         self._saved_gaussian_quadrature_mat = {}
         self._elm_interpolation = {}
@@ -1206,6 +1207,49 @@ class Mesh(MeshBase):
             self.init_interpolation(n_elm_gp)
         return self._saved_gausspoint2node_mat[n_elm_gp]
 
+    def _get_gausspoint2node_l2(self, n_elm_gp=None):
+        if n_elm_gp is None:
+            n_elm_gp = get_default_n_gp(self.elm_type)
+        if n_elm_gp not in self._saved_gausspoint2node_l2:
+            from scipy.sparse import linalg
+
+            node2gp = self._get_node2gausspoint_mat(n_elm_gp)
+            quadrature = self._get_gaussian_quadrature_mat(n_elm_gp)
+            mass = node2gp.T @ quadrature @ node2gp
+            rhs = node2gp.T @ quadrature
+            try:
+                solve = linalg.factorized(mass.tocsc())
+            except RuntimeError as exc:
+                raise ValueError(
+                    "L2 GaussPoint to Node conversion failed because the "
+                    "projection mass matrix is singular. Try a higher number "
+                    "of Gauss points per element or use method='mean'."
+                ) from exc
+            self._saved_gausspoint2node_l2[n_elm_gp] = (solve, rhs)
+        return self._saved_gausspoint2node_l2[n_elm_gp]
+
+    def _gausspoint_to_node(
+        self,
+        data: np.ndarray,
+        n_elm_gp: int | None = None,
+        method: str | None = None,
+    ) -> np.ndarray:
+        if method is None:
+            method = "mean"
+        else:
+            method = method.lower()
+            if method not in ["mean", "l2"]:
+                raise ValueError(
+                    "unknown GaussPoint to Node conversion method "
+                    f"'{method}'. Use 'mean' or 'l2'."
+                )
+
+        if method == "mean":
+            return self._get_gausspoint2node_mat(n_elm_gp) @ data
+
+        solve, rhs = self._get_gausspoint2node_l2(n_elm_gp)
+        return solve(rhs @ data)
+
     def _get_node2gausspoint_mat(self, n_elm_gp=None):
         if n_elm_gp is None:
             n_elm_gp = get_default_n_gp(self.elm_type)
@@ -1271,7 +1315,26 @@ class Mesh(MeshBase):
         convert_from: str | None = None,
         convert_to: str = "GaussPoint",
         n_elm_gp: int | None = None,
+        method: str | None = None,
     ) -> np.ndarray:
+        """
+        Convert a field between node, element and Gauss-point storage.
+
+        Parameters
+        ----------
+        data : ndarray
+            Field values. The last axis stores the points.
+        convert_from, convert_to : {'Node', 'Element', 'GaussPoint'}
+            Source and target storage. If ``convert_from`` is None, it is
+            inferred from the last axis length.
+        n_elm_gp : int, optional
+            Number of Gauss points per element.
+        method : {'mean', 'l2'}, optional
+            Method used when converting Gauss-point values to nodes. ``'mean'``
+            keeps the historical element-wise extrapolation followed by nodal
+            averaging. ``'l2'`` performs a global L2 projection using fedoo's
+            node-to-Gauss-point interpolation and quadrature matrices.
+        """
         if np.isscalar(data):
             return data
 
@@ -1302,7 +1365,7 @@ class Mesh(MeshBase):
 
         # from here data should be defined at 'PG'
         if convert_to == "Node":
-            return (self._get_gausspoint2node_mat(n_elm_gp) @ data).T
+            return self._gausspoint_to_node(data, n_elm_gp, method).T
         elif convert_to == "Element":
             return (np.sum(np.split(data, n_elm_gp), axis=0) / n_elm_gp).T
         else:
@@ -1367,6 +1430,7 @@ class Mesh(MeshBase):
         This method should be used when modifying the element table or when removing or adding nodes.
         """
         self._saved_gausspoint2node_mat = {}
+        self._saved_gausspoint2node_l2 = {}
         self._saved_node2gausspoint_mat = {}
         self._saved_gaussian_quadrature_mat = {}
         self._elm_interpolation = {}

--- a/fedoo/lib_elements/element_list.py
+++ b/fedoo/lib_elements/element_list.py
@@ -57,7 +57,7 @@ _dict_default_n_gp = {
     "lin2interface": 2,
     "quad4interface": 4,
     "tri3": 3,
-    "tri6": 4,
+    "tri6": 7,
     "tri3bubble": 3,
     "quad4": 4,
     "quad4hourglass": 1,
@@ -79,7 +79,7 @@ _dict_default_n_gp = {
     "pquad4": 4,
     "ptri3": 3,
     "pquad8": 9,
-    "ptri6": 4,
+    "ptri6": 7,
     "pquad9": 9,
 }
 

--- a/fedoo/lib_elements/plate.py
+++ b/fedoo/lib_elements/plate.py
@@ -16,7 +16,7 @@ pquad4 = CombinedElement("pquad4", "quad4", default_n_gp=4, local_csys=True)
 #           '__local_csys':True}
 
 # simple tri6 plate
-ptri6 = CombinedElement("ptri6", "tri6", default_n_gp=4, local_csys=True)
+ptri6 = CombinedElement("ptri6", "tri6", default_n_gp=7, local_csys=True)
 # ptri6 = {'__default':['tri6'],
 #          '__local_csys':True}
 

--- a/fedoo/lib_elements/triangle.py
+++ b/fedoo/lib_elements/triangle.py
@@ -140,10 +140,10 @@ class Tri3Bubble(Tri3):
 
 class Tri6(ElementTriangle):
     name = "tri6"
-    default_n_gp = 4
+    default_n_gp = 7
     n_nodes = 6
 
-    def __init__(self, n_elm_gp=4, **kargs):
+    def __init__(self, n_elm_gp=7, **kargs):
         self.xi_nd = np.c_[
             [0.0, 1.0, 0.0, 0.5, 0.5, 0.0], [0.0, 0.0, 1.0, 0.0, 0.5, 0.5]
         ]

--- a/fedoo/util/__init__.py
+++ b/fedoo/util/__init__.py
@@ -8,3 +8,12 @@
 # from .voigt_tensors import StrainTensorList, StressTensorList
 # from .simple_plot import mesh_plot_2d, field_plot_2d
 # from .abaqus_inp import ReadINP
+
+from .recovery import recover_gradient, recover_hessian, to_voigt, to_upper_diagonal
+
+__all__ = [
+    "recover_gradient",
+    "recover_hessian",
+    "to_voigt",
+    "to_upper_diagonal",
+]

--- a/fedoo/util/recovery.py
+++ b/fedoo/util/recovery.py
@@ -2,10 +2,9 @@
 
 Useful as a fast input for metric-based adaptive remeshing (e.g.
 ``mmgpy.metrics.create_metric_from_hessian``). The recovery uses a double
-Galerkin L2-projection: per-element gradient at Gauss points -> lumped
-GP-to-Node averaging via fedoo's cached projection matrix -> repeat for the
-Hessian. All work is a few einsums plus a handful of sparse matvecs; no
-per-vertex Python loop.
+projection: per-element gradient at Gauss points -> nodal values via
+``Mesh.convert_data`` -> repeat for the Hessian. All work is a few einsums plus
+a handful of sparse matvecs; no per-vertex Python loop.
 """
 
 from __future__ import annotations
@@ -19,10 +18,9 @@ if TYPE_CHECKING:
 
 
 def _physical_shape_derivatives(mesh: Mesh, n_elm_gp: int | None = None):
-    """Return (dNdx, proj, n_gp) for the requested integration order.
+    """Return (dNdx, n_gp) for the requested integration order.
 
     dNdx[el, gp, n, i] is dN_n/dx_i at gauss point gp of element el.
-    proj is the cached sparse GP-to-Node lumped averaging matrix.
     """
     if n_elm_gp is None:
         from fedoo.lib_elements.element_list import get_default_n_gp
@@ -51,20 +49,7 @@ def _physical_shape_derivatives(mesh: Mesh, n_elm_gp: int | None = None):
     # dNdx[e, g, n, i] = sum_x dN_xi[g, x, n] * inv_J[e, g, i, x]
     dNdx = np.einsum("gxn, egix -> egni", dN_xi, inv_J)
 
-    proj = mesh._get_gausspoint2node_mat(n_elm_gp)
-    return dNdx, proj, n_elm_gp
-
-
-def _project_gp_field(field_gp: np.ndarray, proj) -> np.ndarray:
-    """Project a GP field of shape (n_el, n_gp, ...) to nodes via proj."""
-    n_el, n_gp = field_gp.shape[:2]
-    tail = field_gp.shape[2:]
-    # GP layout in proj: column index = el + gp*n_el (mesh.py:1138-1142),
-    # i.e. elements vary fastest. Transposing axes 0 and 1 then ravelling
-    # in C order produces exactly that layout.
-    flat = field_gp.transpose(1, 0, *range(2, field_gp.ndim)).reshape(n_el * n_gp, -1)
-    out = proj @ flat
-    return out.reshape(out.shape[0], *tail)
+    return dNdx, n_elm_gp
 
 
 def _validate_scalar_field(mesh: Mesh, field: np.ndarray) -> np.ndarray:
@@ -76,22 +61,16 @@ def _validate_scalar_field(mesh: Mesh, field: np.ndarray) -> np.ndarray:
     return field
 
 
-def _recover_gradient(field: np.ndarray, mesh: Mesh, dNdx, proj) -> np.ndarray:
-    f_elem = field[mesh.elements]
-    g_gp = np.einsum("en, egni -> egi", f_elem, dNdx)
-    return _project_gp_field(g_gp, proj)
-
-
 def recover_gradient(
     mesh: Mesh,
     field: np.ndarray,
     n_elm_gp: int | None = None,
+    method: str | None = "l2",
 ) -> np.ndarray:
     """Recover the nodal gradient of a scalar field on a fedoo mesh.
 
     Computes the gradient at every Gauss point via the FE shape function
-    derivatives, then averages back to nodes through fedoo's cached lumped
-    GP-to-Node projection (``mesh._get_gausspoint2node_mat``).
+    derivatives, then converts back to nodes with ``mesh.convert_data``.
 
     Restricted to volumetric or planar elements (square Jacobian); raises
     ``NotImplementedError`` for shell, beam, or surface-in-3D elements.
@@ -106,6 +85,8 @@ def recover_gradient(
         Scalar nodal values.
     n_elm_gp : int, optional
         Number of Gauss points per element. Defaults to the element default.
+    method : {'mean', 'l2'}, default = 'l2'
+        GaussPoint-to-Node conversion method passed to ``mesh.convert_data``.
 
     Returns
     -------
@@ -113,16 +94,26 @@ def recover_gradient(
         Recovered nodal gradient.
     """
     field = _validate_scalar_field(mesh, field)
-    dNdx, proj, _ = _physical_shape_derivatives(mesh, n_elm_gp)
-    return _recover_gradient(field, mesh, dNdx, proj)
+    dNdx, n_elm_gp = _physical_shape_derivatives(mesh, n_elm_gp)
+
+    grad_gp = np.einsum("en, egni -> egi", field[mesh.elements], dNdx)
+    grad_node = mesh.convert_data(
+        grad_gp.transpose(2, 1, 0).reshape(mesh.ndim, -1),
+        convert_from="GaussPoint",
+        convert_to="Node",
+        n_elm_gp=n_elm_gp,
+        method=method,
+    )
+    return grad_node.T
 
 
 def recover_hessian(
     mesh: Mesh,
     field: np.ndarray,
     n_elm_gp: int | None = None,
+    method: str | None = "l2",
 ) -> np.ndarray:
-    """Recover the nodal Hessian of a scalar field via double L2-projection.
+    """Recover the nodal Hessian of a scalar field via double projection.
 
     Step 1 recovers the gradient as a continuous P1 nodal vector field.
     Step 2 takes the gradient of each component and projects back to nodes,
@@ -147,6 +138,8 @@ def recover_hessian(
         Scalar nodal values.
     n_elm_gp : int, optional
         Number of Gauss points per element. Defaults to the element default.
+    method : {'mean', 'l2'}, default='l2'
+        GaussPoint-to-Node conversion method passed to ``mesh.convert_data``.
 
     Returns
     -------
@@ -154,15 +147,32 @@ def recover_hessian(
         Symmetric Hessian tensor at every node.
     """
     field = _validate_scalar_field(mesh, field)
-    dNdx, proj, _ = _physical_shape_derivatives(mesh, n_elm_gp)
-    g_node = _recover_gradient(field, mesh, dNdx, proj)
+    dNdx, n_elm_gp = _physical_shape_derivatives(mesh, n_elm_gp)
 
-    g_elem = g_node[mesh.elements]
-    # H_gp[e, g, j, i] = sum_n g_elem[e, n, j] * dNdx[e, g, n, i]
-    H_gp = np.einsum("enj, egni -> egji", g_elem, dNdx)
-    H = _project_gp_field(H_gp, proj)
+    grad_gp = np.einsum("en, egni -> egi", field[mesh.elements], dNdx)
+    grad_node = mesh.convert_data(
+        grad_gp.transpose(2, 1, 0).reshape(mesh.ndim, -1),
+        convert_from="GaussPoint",
+        convert_to="Node",
+        n_elm_gp=n_elm_gp,
+        method=method,
+    ).T
 
-    return 0.5 * (H + H.swapaxes(-1, -2))
+    # hessian_gp[e, g, j, i] = sum_n grad_node[e, n, j] * dNdx[e, g, n, i]
+    hessian_gp = np.einsum("enj, egni -> egji", grad_node[mesh.elements], dNdx)
+    hessian = (
+        mesh.convert_data(
+            hessian_gp.transpose(2, 3, 1, 0).reshape(mesh.ndim * mesh.ndim, -1),
+            convert_from="GaussPoint",
+            convert_to="Node",
+            n_elm_gp=n_elm_gp,
+            method=method,
+        )
+        .reshape(mesh.ndim, mesh.ndim, mesh.n_nodes)
+        .transpose(2, 0, 1)
+    )
+
+    return 0.5 * (hessian + hessian.swapaxes(-1, -2))
 
 
 def to_voigt(T: np.ndarray) -> np.ndarray:

--- a/fedoo/util/recovery.py
+++ b/fedoo/util/recovery.py
@@ -1,0 +1,204 @@
+"""Vectorized FE-aware nodal gradient and Hessian recovery on fedoo meshes.
+
+Useful as a fast input for metric-based adaptive remeshing (e.g.
+``mmgpy.metrics.create_metric_from_hessian``). The recovery uses a double
+Galerkin L2-projection: per-element gradient at Gauss points -> lumped
+GP-to-Node averaging via fedoo's cached projection matrix -> repeat for the
+Hessian. All work is a few einsums plus a handful of sparse matvecs; no
+per-vertex Python loop.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from fedoo.core.mesh import Mesh
+
+
+def _physical_shape_derivatives(mesh: Mesh, n_elm_gp: int | None = None):
+    """Return (dNdx, proj, n_gp) for the requested integration order.
+
+    dNdx[el, gp, n, i] is dN_n/dx_i at gauss point gp of element el.
+    proj is the cached sparse GP-to-Node lumped averaging matrix.
+    """
+    if n_elm_gp is None:
+        from fedoo.lib_elements.element_list import get_default_n_gp
+
+        n_elm_gp = get_default_n_gp(mesh.elm_type)
+
+    # Triggers init_interpolation + compute_jacobian_with_inverse, populating
+    # inv_jacobian_matrix on the cached element interpolation object.
+    mesh._get_gaussian_quadrature_mat(n_elm_gp)
+
+    elm = mesh._elm_interpolation[n_elm_gp]
+    inv_J = elm.inv_jacobian_matrix  # (n_el, n_gp, ndim_phys, ndim_xi)
+
+    if inv_J.shape[-1] != inv_J.shape[-2]:
+        raise NotImplementedError(
+            "recover_gradient/recover_hessian require a square Jacobian "
+            "(volumetric or planar elements). Got inv_J shape "
+            f"{inv_J.shape} on element type '{mesh.elm_type}'."
+        )
+
+    # shape_function_derivative returns a list of length n_gp, each (ndim_xi, n_nodes_per_elm)
+    dN_xi = np.stack(elm.shape_function_derivative(elm.xi_pg), axis=0)
+    # dN_xi[g, x, n] = dN_n/dxi_x at gp g
+
+    # dNdx[e, g, n, i] = sum_x dN_xi[g, x, n] * inv_J[e, g, i, x]
+    dNdx = np.einsum("gxn, egix -> egni", dN_xi, inv_J, optimize=True)
+
+    proj = mesh._get_gausspoint2node_mat(n_elm_gp)  # sparse (n_nodes, n_el * n_gp)
+    return dNdx, proj, n_elm_gp
+
+
+def _project_gp_field(field_gp: np.ndarray, proj) -> np.ndarray:
+    """Project a GP field of shape (n_el, n_gp, ...) to nodes via proj.
+
+    Returns a node field with leading shape (n_nodes, ...).
+    """
+    n_el, n_gp = field_gp.shape[:2]
+    tail = field_gp.shape[2:]
+    # GP layout in proj: column index = el + gp*n_el (mesh.py:1138-1142),
+    # i.e. elements vary fastest. Transposing axes 0 and 1 then ravelling
+    # in C order produces exactly that layout.
+    flat = field_gp.transpose(1, 0, *range(2, field_gp.ndim)).reshape(n_el * n_gp, -1)
+    out = proj @ flat  # (n_nodes, prod(tail))
+    return out.reshape(out.shape[0], *tail)
+
+
+def recover_gradient(
+    mesh: Mesh,
+    field: np.ndarray,
+    n_elm_gp: int | None = None,
+) -> np.ndarray:
+    """Recover the nodal gradient of a scalar field on a fedoo mesh.
+
+    Computes the gradient at every Gauss point via the FE shape function
+    derivatives, then averages back to nodes through fedoo's cached lumped
+    GP-to-Node projection (``mesh._get_gausspoint2node_mat``).
+
+    Parameters
+    ----------
+    mesh : fedoo.Mesh
+        The mesh on which the field is defined.
+    field : (n_nodes,) ndarray
+        Scalar nodal values.
+    n_elm_gp : int, optional
+        Number of Gauss points per element. Defaults to the element default.
+
+    Returns
+    -------
+    (n_nodes, ndim) ndarray
+        Recovered nodal gradient.
+    """
+    field = np.asarray(field, dtype=np.float64)
+    if field.shape != (mesh.n_nodes,):
+        raise ValueError(
+            f"field must have shape (n_nodes={mesh.n_nodes},), got {field.shape}"
+        )
+
+    dNdx, proj, _ = _physical_shape_derivatives(mesh, n_elm_gp)
+    f_elem = field[mesh.elements]  # (n_el, n_elm_nd)
+    g_gp = np.einsum("en, egni -> egi", f_elem, dNdx, optimize=True)
+    return _project_gp_field(g_gp, proj)
+
+
+def recover_hessian(
+    mesh: Mesh,
+    field: np.ndarray,
+    n_elm_gp: int | None = None,
+) -> np.ndarray:
+    """Recover the nodal Hessian of a scalar field via double L2-projection.
+
+    Step 1 recovers the gradient as a continuous P1 nodal vector field.
+    Step 2 takes the gradient of each component and projects back to nodes,
+    giving a full (possibly non-symmetric) tensor; the result is then
+    symmetrized.
+
+    Pack the result with :func:`to_voigt` for the fedoo convention
+    (``[XX, YY, ZZ, XY, XZ, YZ]``) or :func:`to_upper_diagonal` for the
+    row-major upper triangle (``[m11, m12, m13, m22, m23, m33]``), the layout
+    consumed by mmg's ``MMG{2,3}D_Set_tensorSols``.
+
+    Parameters
+    ----------
+    mesh : fedoo.Mesh
+    field : (n_nodes,) ndarray
+        Scalar nodal values.
+    n_elm_gp : int, optional
+        Number of Gauss points per element. Defaults to the element default.
+
+    Returns
+    -------
+    (n_nodes, ndim, ndim) ndarray
+        Symmetric Hessian tensor at every node.
+    """
+    field = np.asarray(field, dtype=np.float64)
+    if field.shape != (mesh.n_nodes,):
+        raise ValueError(
+            f"field must have shape (n_nodes={mesh.n_nodes},), got {field.shape}"
+        )
+
+    dNdx, proj, _ = _physical_shape_derivatives(mesh, n_elm_gp)
+
+    f_elem = field[mesh.elements]
+    g_gp = np.einsum("en, egni -> egi", f_elem, dNdx, optimize=True)
+    g_node = _project_gp_field(g_gp, proj)  # (n_nodes, ndim)
+
+    # Step 2: gradient of g, component by component, all in one einsum.
+    g_elem = g_node[mesh.elements]  # (n_el, n_elm_nd, ndim)
+    # H_gp[e, g, j, i] = sum_n g_elem[e, n, j] * dNdx[e, g, n, i]
+    H_gp = np.einsum("enj, egni -> egji", g_elem, dNdx, optimize=True)
+    H = _project_gp_field(H_gp, proj)  # (n_nodes, ndim, ndim)
+
+    return 0.5 * (H + H.swapaxes(-1, -2))
+
+
+def to_voigt(T: np.ndarray) -> np.ndarray:
+    """Pack a symmetric tensor field to fedoo Voigt order.
+
+    3D ``(n, 3, 3)`` -> ``(6, n)`` in order ``[XX, YY, ZZ, XY, XZ, YZ]``.
+    2D ``(n, 2, 2)`` -> ``(3, n)`` in order ``[XX, YY, XY]``.
+
+    Matches the storage convention of
+    :class:`fedoo.util.voigt_tensors._SymmetricTensorList`.
+    """
+    T = np.asarray(T)
+    if T.ndim != 3 or T.shape[-1] != T.shape[-2]:
+        raise ValueError(f"expected (n, d, d) tensor field, got {T.shape}")
+    d = T.shape[-1]
+    if d == 3:
+        return np.stack(
+            [T[:, 0, 0], T[:, 1, 1], T[:, 2, 2], T[:, 0, 1], T[:, 0, 2], T[:, 1, 2]],
+            axis=0,
+        )
+    if d == 2:
+        return np.stack([T[:, 0, 0], T[:, 1, 1], T[:, 0, 1]], axis=0)
+    raise ValueError(f"unsupported tensor dimension {d}; expected 2 or 3")
+
+
+def to_upper_diagonal(T: np.ndarray) -> np.ndarray:
+    """Pack a symmetric tensor field to its row-major upper triangle.
+
+    3D ``(n, 3, 3)`` -> ``(n, 6)`` in order ``[m11, m12, m13, m22, m23, m33]``.
+    2D ``(n, 2, 2)`` -> ``(n, 3)`` in order ``[m11, m12, m22]``.
+
+    This is the layout consumed by mmg's ``MMG3D_Set_tensorSols`` /
+    ``MMG2D_Set_tensorSols`` (and therefore by mmgpy), but the helper is
+    consumer-agnostic and applies to any symmetric tensor field.
+    """
+    T = np.asarray(T)
+    if T.ndim != 3 or T.shape[-1] != T.shape[-2]:
+        raise ValueError(f"expected (n, d, d) tensor field, got {T.shape}")
+    d = T.shape[-1]
+    if d == 3:
+        return np.stack(
+            [T[:, 0, 0], T[:, 0, 1], T[:, 0, 2], T[:, 1, 1], T[:, 1, 2], T[:, 2, 2]],
+            axis=1,
+        )
+    if d == 2:
+        return np.stack([T[:, 0, 0], T[:, 0, 1], T[:, 1, 1]], axis=1)
+    raise ValueError(f"unsupported tensor dimension {d}; expected 2 or 3")

--- a/fedoo/util/recovery.py
+++ b/fedoo/util/recovery.py
@@ -43,30 +43,43 @@ def _physical_shape_derivatives(mesh: Mesh, n_elm_gp: int | None = None):
             f"{inv_J.shape} on element type '{mesh.elm_type}'."
         )
 
-    # shape_function_derivative returns a list of length n_gp, each (ndim_xi, n_nodes_per_elm)
-    dN_xi = np.stack(elm.shape_function_derivative(elm.xi_pg), axis=0)
+    # Reuse the per-element-class cache populated in __init__
+    # (e.g. ElementTriangle.__init__ at fedoo/lib_elements/triangle.py:15).
     # dN_xi[g, x, n] = dN_n/dxi_x at gp g
+    dN_xi = np.stack(elm.shape_function_derivative_gp, axis=0)
 
     # dNdx[e, g, n, i] = sum_x dN_xi[g, x, n] * inv_J[e, g, i, x]
-    dNdx = np.einsum("gxn, egix -> egni", dN_xi, inv_J, optimize=True)
+    dNdx = np.einsum("gxn, egix -> egni", dN_xi, inv_J)
 
-    proj = mesh._get_gausspoint2node_mat(n_elm_gp)  # sparse (n_nodes, n_el * n_gp)
+    proj = mesh._get_gausspoint2node_mat(n_elm_gp)
     return dNdx, proj, n_elm_gp
 
 
 def _project_gp_field(field_gp: np.ndarray, proj) -> np.ndarray:
-    """Project a GP field of shape (n_el, n_gp, ...) to nodes via proj.
-
-    Returns a node field with leading shape (n_nodes, ...).
-    """
+    """Project a GP field of shape (n_el, n_gp, ...) to nodes via proj."""
     n_el, n_gp = field_gp.shape[:2]
     tail = field_gp.shape[2:]
     # GP layout in proj: column index = el + gp*n_el (mesh.py:1138-1142),
     # i.e. elements vary fastest. Transposing axes 0 and 1 then ravelling
     # in C order produces exactly that layout.
     flat = field_gp.transpose(1, 0, *range(2, field_gp.ndim)).reshape(n_el * n_gp, -1)
-    out = proj @ flat  # (n_nodes, prod(tail))
+    out = proj @ flat
     return out.reshape(out.shape[0], *tail)
+
+
+def _validate_scalar_field(mesh: Mesh, field: np.ndarray) -> np.ndarray:
+    field = np.asarray(field, dtype=np.float64)
+    if field.shape != (mesh.n_nodes,):
+        raise ValueError(
+            f"field must have shape (n_nodes={mesh.n_nodes},), got {field.shape}"
+        )
+    return field
+
+
+def _recover_gradient(field: np.ndarray, mesh: Mesh, dNdx, proj) -> np.ndarray:
+    f_elem = field[mesh.elements]
+    g_gp = np.einsum("en, egni -> egi", f_elem, dNdx)
+    return _project_gp_field(g_gp, proj)
 
 
 def recover_gradient(
@@ -79,6 +92,11 @@ def recover_gradient(
     Computes the gradient at every Gauss point via the FE shape function
     derivatives, then averages back to nodes through fedoo's cached lumped
     GP-to-Node projection (``mesh._get_gausspoint2node_mat``).
+
+    Restricted to volumetric or planar elements (square Jacobian); raises
+    ``NotImplementedError`` for shell, beam, or surface-in-3D elements.
+    Boundary nodes use one-sided element averaging and are therefore less
+    accurate than interior nodes.
 
     Parameters
     ----------
@@ -94,16 +112,9 @@ def recover_gradient(
     (n_nodes, ndim) ndarray
         Recovered nodal gradient.
     """
-    field = np.asarray(field, dtype=np.float64)
-    if field.shape != (mesh.n_nodes,):
-        raise ValueError(
-            f"field must have shape (n_nodes={mesh.n_nodes},), got {field.shape}"
-        )
-
+    field = _validate_scalar_field(mesh, field)
     dNdx, proj, _ = _physical_shape_derivatives(mesh, n_elm_gp)
-    f_elem = field[mesh.elements]  # (n_el, n_elm_nd)
-    g_gp = np.einsum("en, egni -> egi", f_elem, dNdx, optimize=True)
-    return _project_gp_field(g_gp, proj)
+    return _recover_gradient(field, mesh, dNdx, proj)
 
 
 def recover_hessian(
@@ -117,6 +128,12 @@ def recover_hessian(
     Step 2 takes the gradient of each component and projects back to nodes,
     giving a full (possibly non-symmetric) tensor; the result is then
     symmetrized.
+
+    Restricted to volumetric or planar elements (square Jacobian); raises
+    ``NotImplementedError`` for shell, beam, or surface-in-3D elements.
+    Boundary nodes use one-sided element averaging and are therefore less
+    accurate than interior nodes - acceptable when feeding an mmg metric,
+    which clips eigenvalues by ``hmin``/``hmax``.
 
     Pack the result with :func:`to_voigt` for the fedoo convention
     (``[XX, YY, ZZ, XY, XZ, YZ]``) or :func:`to_upper_diagonal` for the
@@ -136,23 +153,14 @@ def recover_hessian(
     (n_nodes, ndim, ndim) ndarray
         Symmetric Hessian tensor at every node.
     """
-    field = np.asarray(field, dtype=np.float64)
-    if field.shape != (mesh.n_nodes,):
-        raise ValueError(
-            f"field must have shape (n_nodes={mesh.n_nodes},), got {field.shape}"
-        )
-
+    field = _validate_scalar_field(mesh, field)
     dNdx, proj, _ = _physical_shape_derivatives(mesh, n_elm_gp)
+    g_node = _recover_gradient(field, mesh, dNdx, proj)
 
-    f_elem = field[mesh.elements]
-    g_gp = np.einsum("en, egni -> egi", f_elem, dNdx, optimize=True)
-    g_node = _project_gp_field(g_gp, proj)  # (n_nodes, ndim)
-
-    # Step 2: gradient of g, component by component, all in one einsum.
-    g_elem = g_node[mesh.elements]  # (n_el, n_elm_nd, ndim)
+    g_elem = g_node[mesh.elements]
     # H_gp[e, g, j, i] = sum_n g_elem[e, n, j] * dNdx[e, g, n, i]
-    H_gp = np.einsum("enj, egni -> egji", g_elem, dNdx, optimize=True)
-    H = _project_gp_field(H_gp, proj)  # (n_nodes, ndim, ndim)
+    H_gp = np.einsum("enj, egni -> egji", g_elem, dNdx)
+    H = _project_gp_field(H_gp, proj)
 
     return 0.5 * (H + H.swapaxes(-1, -2))
 

--- a/fedoo/util/voigt_tensors.py
+++ b/fedoo/util/voigt_tensors.py
@@ -182,9 +182,9 @@ class _SymetricTensorList(list):  # base class for StressTensorList and StrainTe
             if np.isscalar(self[i]) and self[i] == 0:
                 self[i] = np.zeros(n)
 
-    def convert(self, assemb, convert_from=None, convert_to="GaussPoint"):
+    def convert(self, assemb, convert_from=None, convert_to="GaussPoint", method=None):
         return self.__class__(
-            [assemb.convert_data(S, convert_from, convert_to) for S in self]
+            [assemb.convert_data(S, convert_from, convert_to, method) for S in self]
         )
 
     def copy(self, asarray=False):

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,140 @@
+"""Tests for fedoo.util.recovery (nodal gradient and Hessian recovery)."""
+
+import numpy as np
+import pytest
+
+import fedoo as fd
+
+
+def _interior_mask(mesh, margin=0.15):
+    """Boolean mask of nodes that are at least `margin` (relative bbox)
+    away from the bounding box, i.e. away from the mesh boundary where the
+    lumped GP-to-Node averaging is one-sided.
+    """
+    crd = mesh.nodes
+    lo = crd.min(axis=0)
+    hi = crd.max(axis=0)
+    span = hi - lo
+    eps = margin * span
+    return np.all((crd > lo + eps) & (crd < hi - eps), axis=1)
+
+
+def _eval_field(mesh, f):
+    return f(*mesh.nodes.T)
+
+
+@pytest.mark.parametrize(
+    "elm_type, nx, ny",
+    [("quad4", 21, 21), ("tri3", 21, 21), ("tri6", 21, 21)],
+)
+def test_recover_hessian_2d_quadratic(elm_type, nx, ny):
+    """Quadratic 2D field: H is constant; recovery must hit it on interior nodes."""
+    mesh = fd.mesh.rectangle_mesh(nx=nx, ny=ny, elm_type=elm_type)
+
+    # f(x,y) = x^2 + x*y + 2*y^2  =>  H = [[2, 1], [1, 4]]
+    field = _eval_field(mesh, lambda x, y: x * x + x * y + 2 * y * y)
+    H = fd.recover_hessian(mesh, field)
+
+    assert H.shape == (mesh.n_nodes, 2, 2)
+    # Symmetric by construction (post-symmetrize step).
+    np.testing.assert_allclose(H[:, 0, 1], H[:, 1, 0], atol=1e-12)
+
+    H_expected = np.array([[2.0, 1.0], [1.0, 4.0]])
+    interior = _interior_mask(mesh)
+    np.testing.assert_allclose(
+        H[interior],
+        np.broadcast_to(H_expected, (interior.sum(), 2, 2)),
+        atol=1e-9,
+    )
+
+
+def test_recover_hessian_2d_linear_field_is_zero():
+    """Linear field has zero Hessian everywhere (boundary too)."""
+    mesh = fd.mesh.rectangle_mesh(nx=11, ny=11, elm_type="tri3")
+    field = _eval_field(mesh, lambda x, y: 2.0 * x + 3.0 * y - 0.5)
+    H = fd.recover_hessian(mesh, field)
+    np.testing.assert_allclose(H, 0.0, atol=1e-10)
+
+
+def test_recover_hessian_3d_quadratic_hex8():
+    """Quadratic 3D field on hex8: H constant on interior nodes."""
+    mesh = fd.mesh.box_mesh(nx=11, ny=11, nz=11, elm_type="hex8")
+    # f(x,y,z) = x^2 + 2*y^2 + 3*z^2 + x*y
+    # H = [[2, 1, 0], [1, 4, 0], [0, 0, 6]]
+    field = _eval_field(mesh, lambda x, y, z: x * x + 2 * y * y + 3 * z * z + x * y)
+    H = fd.recover_hessian(mesh, field)
+
+    assert H.shape == (mesh.n_nodes, 3, 3)
+    np.testing.assert_allclose(H, H.swapaxes(-1, -2), atol=1e-12)
+
+    H_expected = np.array([[2.0, 1.0, 0.0], [1.0, 4.0, 0.0], [0.0, 0.0, 6.0]])
+    interior = _interior_mask(mesh)
+    np.testing.assert_allclose(
+        H[interior],
+        np.broadcast_to(H_expected, (interior.sum(), 3, 3)),
+        atol=1e-9,
+    )
+
+
+def test_recover_gradient_2d():
+    """Gradient of f(x,y) = 3x + 2y is the constant vector [3, 2]."""
+    mesh = fd.mesh.rectangle_mesh(nx=11, ny=11, elm_type="quad4")
+    field = _eval_field(mesh, lambda x, y: 3.0 * x + 2.0 * y)
+    g = fd.recover_gradient(mesh, field)
+
+    assert g.shape == (mesh.n_nodes, 2)
+    np.testing.assert_allclose(g, np.broadcast_to([3.0, 2.0], g.shape), atol=1e-10)
+
+
+def test_to_upper_diagonal_3d_round_trip():
+    """to_upper_diagonal must recover the (n, 6) packing in mmg's order."""
+    rng = np.random.default_rng(0)
+    n = 7
+    H = rng.normal(size=(n, 3, 3))
+    H = 0.5 * (H + H.swapaxes(-1, -2))
+
+    packed = fd.to_upper_diagonal(H)
+    assert packed.shape == (n, 6)
+    # Order [m11, m12, m13, m22, m23, m33].
+    np.testing.assert_array_equal(packed[:, 0], H[:, 0, 0])
+    np.testing.assert_array_equal(packed[:, 1], H[:, 0, 1])
+    np.testing.assert_array_equal(packed[:, 2], H[:, 0, 2])
+    np.testing.assert_array_equal(packed[:, 3], H[:, 1, 1])
+    np.testing.assert_array_equal(packed[:, 4], H[:, 1, 2])
+    np.testing.assert_array_equal(packed[:, 5], H[:, 2, 2])
+
+
+def test_to_upper_diagonal_2d():
+    rng = np.random.default_rng(1)
+    n = 5
+    H = rng.normal(size=(n, 2, 2))
+    H = 0.5 * (H + H.swapaxes(-1, -2))
+
+    packed = fd.to_upper_diagonal(H)
+    assert packed.shape == (n, 3)
+    np.testing.assert_array_equal(packed[:, 0], H[:, 0, 0])
+    np.testing.assert_array_equal(packed[:, 1], H[:, 0, 1])
+    np.testing.assert_array_equal(packed[:, 2], H[:, 1, 1])
+
+
+def test_to_voigt_3d():
+    """to_voigt must produce (6, n) in fedoo Voigt order [XX,YY,ZZ,XY,XZ,YZ]."""
+    rng = np.random.default_rng(2)
+    n = 4
+    H = rng.normal(size=(n, 3, 3))
+    H = 0.5 * (H + H.swapaxes(-1, -2))
+
+    voigt = fd.to_voigt(H)
+    assert voigt.shape == (6, n)
+    np.testing.assert_array_equal(voigt[0], H[:, 0, 0])
+    np.testing.assert_array_equal(voigt[1], H[:, 1, 1])
+    np.testing.assert_array_equal(voigt[2], H[:, 2, 2])
+    np.testing.assert_array_equal(voigt[3], H[:, 0, 1])
+    np.testing.assert_array_equal(voigt[4], H[:, 0, 2])
+    np.testing.assert_array_equal(voigt[5], H[:, 1, 2])
+
+
+def test_recover_hessian_validates_shape():
+    mesh = fd.mesh.rectangle_mesh(nx=5, ny=5, elm_type="quad4")
+    with pytest.raises(ValueError, match="shape"):
+        fd.recover_hessian(mesh, np.zeros(mesh.n_nodes - 1))

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -33,7 +33,7 @@ def test_recover_hessian_2d_quadratic(elm_type, nx, ny):
 
     # f(x,y) = x^2 + x*y + 2*y^2  =>  H = [[2, 1], [1, 4]]
     field = _eval_field(mesh, lambda x, y: x * x + x * y + 2 * y * y)
-    H = fd.recover_hessian(mesh, field)
+    H = fd.recover_hessian(mesh, field, method="mean")
 
     assert H.shape == (mesh.n_nodes, 2, 2)
     # Symmetric by construction (post-symmetrize step).
@@ -52,7 +52,7 @@ def test_recover_hessian_2d_linear_field_is_zero():
     """Linear field has zero Hessian everywhere (boundary too)."""
     mesh = fd.mesh.rectangle_mesh(nx=11, ny=11, elm_type="tri3")
     field = _eval_field(mesh, lambda x, y: 2.0 * x + 3.0 * y - 0.5)
-    H = fd.recover_hessian(mesh, field)
+    H = fd.recover_hessian(mesh, field, method="mean")
     np.testing.assert_allclose(H, 0.0, atol=1e-10)
 
 
@@ -62,7 +62,7 @@ def test_recover_hessian_3d_quadratic_hex8():
     # f(x,y,z) = x^2 + 2*y^2 + 3*z^2 + x*y
     # H = [[2, 1, 0], [1, 4, 0], [0, 0, 6]]
     field = _eval_field(mesh, lambda x, y, z: x * x + 2 * y * y + 3 * z * z + x * y)
-    H = fd.recover_hessian(mesh, field)
+    H = fd.recover_hessian(mesh, field, method="mean")
 
     assert H.shape == (mesh.n_nodes, 3, 3)
     np.testing.assert_allclose(H, H.swapaxes(-1, -2), atol=1e-12)
@@ -84,6 +84,76 @@ def test_recover_gradient_2d():
 
     assert g.shape == (mesh.n_nodes, 2)
     np.testing.assert_allclose(g, np.broadcast_to([3.0, 2.0], g.shape), atol=1e-10)
+
+
+def test_recover_hessian_default_l2_uses_tri6_default_quadrature():
+    assert fd.lib_elements.get_default_n_gp("tri6") == 7
+    assert fd.lib_elements.get_default_n_gp("ptri6") == 7
+
+    mesh = fd.mesh.rectangle_mesh(nx=21, ny=21, elm_type="tri6")
+    field = _eval_field(mesh, lambda x, y: x * x + x * y + 2 * y * y)
+
+    H = fd.recover_hessian(mesh, field)
+
+    H_expected = np.array([[2.0, 1.0], [1.0, 4.0]])
+    interior = _interior_mask(mesh)
+    np.testing.assert_allclose(
+        H[interior],
+        np.broadcast_to(H_expected, (interior.sum(), 2, 2)),
+        atol=1e-9,
+    )
+
+
+def test_l2_gausspoint_to_node_projection_recovers_fe_field():
+    """The L2 conversion in Mesh.convert_data recovers interpolated FE fields."""
+    mesh = fd.mesh.rectangle_mesh(nx=7, ny=6, elm_type="quad4")
+    field = _eval_field(mesh, lambda x, y: 1.0 + 2.0 * x - 3.0 * y + x * y)
+
+    field_gp = mesh.convert_data(
+        field,
+        convert_from="Node",
+        convert_to="GaussPoint",
+        n_elm_gp=4,
+    )
+    recovered = mesh.convert_data(
+        field_gp,
+        convert_from="GaussPoint",
+        convert_to="Node",
+        n_elm_gp=4,
+        method="l2",
+    )
+
+    np.testing.assert_allclose(recovered, field, atol=1e-12)
+
+
+def test_mean_gausspoint_to_node_projection_keeps_existing_default():
+    mesh = fd.mesh.rectangle_mesh(nx=4, ny=4, elm_type="quad4")
+    field_gp = np.arange(mesh.n_elements * 4, dtype=float)
+
+    default = mesh.convert_data(field_gp, "GaussPoint", "Node", n_elm_gp=4)
+    explicit = mesh.convert_data(
+        field_gp,
+        "GaussPoint",
+        "Node",
+        n_elm_gp=4,
+        method="mean",
+    )
+
+    np.testing.assert_array_equal(default, explicit)
+
+
+def test_l2_projection_reports_singular_mass_matrix():
+    mesh = fd.mesh.rectangle_mesh(nx=4, ny=4, elm_type="quad4")
+    field_gp = np.arange(mesh.n_elements, dtype=float)
+
+    with pytest.raises(ValueError, match="singular"):
+        mesh.convert_data(
+            field_gp,
+            convert_from="GaussPoint",
+            convert_to="Node",
+            n_elm_gp=1,
+            method="l2",
+        )
 
 
 def test_to_upper_diagonal_3d_round_trip():

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -142,6 +142,64 @@ def test_mean_gausspoint_to_node_projection_keeps_existing_default():
     np.testing.assert_array_equal(default, explicit)
 
 
+def test_spr_gausspoint_to_node_projection_recovers_linear_field():
+    mesh = fd.mesh.rectangle_mesh(nx=6, ny=5, elm_type="tri3")
+    gp_coordinates = mesh.gausspoint_coordinates()
+    field_gp = 1.0 + 2.0 * gp_coordinates[:, 0] - 0.5 * gp_coordinates[:, 1]
+
+    recovered = mesh.convert_data(
+        field_gp,
+        convert_from="GaussPoint",
+        convert_to="Node",
+        method="spr",
+    )
+    expected = 1.0 + 2.0 * mesh.nodes[:, 0] - 0.5 * mesh.nodes[:, 1]
+
+    np.testing.assert_allclose(recovered, expected, atol=1e-12)
+
+
+def test_spr_gausspoint_to_node_projection_handles_components():
+    mesh = fd.mesh.rectangle_mesh(nx=5, ny=4, elm_type="quad4")
+    gp_coordinates = mesh.gausspoint_coordinates()
+    field_gp = np.vstack(
+        (
+            1.0 + gp_coordinates[:, 0] + 2.0 * gp_coordinates[:, 1],
+            -2.0 + 0.5 * gp_coordinates[:, 0] - gp_coordinates[:, 1],
+        )
+    )
+
+    recovered = mesh.convert_data(
+        field_gp,
+        convert_from="GaussPoint",
+        convert_to="Node",
+        method="spr",
+    )
+    expected = np.vstack(
+        (
+            1.0 + mesh.nodes[:, 0] + 2.0 * mesh.nodes[:, 1],
+            -2.0 + 0.5 * mesh.nodes[:, 0] - mesh.nodes[:, 1],
+        )
+    )
+
+    np.testing.assert_allclose(recovered, expected, atol=1e-12)
+
+
+def test_spr_gausspoint_to_node_projection_handles_embedded_surface():
+    mesh = fd.mesh.rectangle_mesh(nx=5, ny=4, elm_type="quad4", ndim=3)
+    gp_coordinates = mesh.gausspoint_coordinates()
+    field_gp = 1.0 + gp_coordinates[:, 0] + 2.0 * gp_coordinates[:, 1]
+
+    recovered = mesh.convert_data(
+        field_gp,
+        convert_from="GaussPoint",
+        convert_to="Node",
+        method="spr",
+    )
+    expected = 1.0 + mesh.nodes[:, 0] + 2.0 * mesh.nodes[:, 1]
+
+    np.testing.assert_allclose(recovered, expected, atol=1e-12)
+
+
 def test_l2_projection_reports_singular_mass_matrix():
     mesh = fd.mesh.rectangle_mesh(nx=4, ny=4, elm_type="quad4")
     field_gp = np.arange(mesh.n_elements, dtype=float)


### PR DESCRIPTION
Introduce fedoo.util.recovery with vectorized FE-aware recover_gradient, recover_hessian, and helpers to_voigt/to_upper_diagonal (double Galerkin L2-projection, no per-vertex Python loops). Export these functions from fedoo and fedoo.util, add tests exercising 2D/3D and various element types, and include an example (examples/adaptive/hessian_recovery.py) demonstrating usage and VTK output.

Add l2 projection and spr method to the Mesh.convert_data for gausspoint to node conversion (used for recovery).