### PR TITLE
Treat distributed loads as Neumann boundary conditions

### DIFF
--- a/docs/boundary_conditions.rst
+++ b/docs/boundary_conditions.rst
@@ -108,9 +108,36 @@ ____________________________________________
 Avdanced BC and constraints
 ==============================
 
-Distributed loads are applied to a Problem by building dedicated assembly
-objects. To add them to a problem, one should add the constraint assembly
-to the assembly defining the stiffness matrix.
+Distributed loads are defined by dedicated assembly objects. The recommended
+way to apply them is to add the load assembly to the problem boundary
+conditions. If the assembly provides an ``as_neumann()`` method,
+:py:meth:`fedoo.ListBC.add` automatically converts it to an equivalent
+Neumann boundary condition. This is especially useful for nonlinear problems:
+the load is included in the external force vector, follows the usual load
+coefficient, and is taken into account by the residual normalization.
+
+.. code-block:: python
+
+    solid_assembly = fd.Assembly.create(wf, mesh)
+    pressure = fd.constraint.Pressure(surface_mesh, value, nlgeom=True)
+
+    pb = fd.problem.NonLinear(solid_assembly, nlgeom=True)
+    pb.bc.add(pressure)
+
+The explicit form is also available:
+
+.. code-block:: python
+
+    pb.bc.add(pressure.as_neumann())
+
+The load assembly can still be combined directly with the mechanical assembly.
+This form is kept as an alternative, but is not recommended for nonlinear
+analyses because the load is part of the residual assembly rather than a
+boundary-condition force.
+
+.. code-block:: python
+
+    pb = fd.problem.Linear(solid_assembly + pressure)
 
 .. autosummary::
     :toctree: generated/
@@ -120,8 +147,8 @@ to the assembly defining the stiffness matrix.
     fedoo.constraint.Pressure
     fedoo.constraint.SurfaceForce
 
-Some advanced constraints base on multiple linearized MPC are available in
-fedoo. They can be created and add to the problem with the pb.bc.add method.
+Some advanced constraints based on multiple linearized MPC are available in
+fedoo. They can be created and added to the problem with the pb.bc.add method.
 
 .. autosummary::
    :toctree: generated/

--- a/examples/01-simple/spherical_shell_compression.py
+++ b/examples/01-simple/spherical_shell_compression.py
@@ -48,27 +48,41 @@ boundaries = mesh.find_elements(
 )
 
 ###############################################################################
-# Now we build the pressure assembly by extracting the surface mesh.
-# The pressure assembly is then added to the solid_assembly to form
-# the global assembly.
+# Now we build the pressure load by extracting the loaded surface mesh.
+# For nonlinear analyses, the pressure is added as an external Neumann boundary
+# condition so that the residual normalization sees the applied load.
 
 pressure_assembly = fd.constraint.Pressure(
     mesh.extract_elements(boundaries),
     pressure,
 )
-assembly = solid_assembly + pressure_assembly
 
 ###############################################################################
-# Define a linear analysis and solve the problem.
+# Define a nonlinear analysis and solve the problem.
 #
 # .. note::
-#    Here we don't need to add other boundary conditions. The rigid body
-#    displacements and rotations of the sphere aren't constrained but the solver
-#    find a solution that is unique in terms of strain and stress (but not
-#    for displacements or rotations)
+#   To improve numerical stability, a few displacement boundary conditions are
+#   added to remove rigid-body motions. These constraints do not affect the
+#   strain/stress solution because they only suppress the nullspace modes.
+#   Without them, the unconstrained problem is singular; some solvers may still
+#   return a usable strain/stress field, but the displacement field can contain
+#   arbitrary rigid-body motion.
+#
+assembly = solid_assembly
 
-pb = fd.problem.Linear(assembly)
-pb.solve()
+pb = fd.problem.NonLinear(assembly, nlgeom=False)
+pb.bc.add(pressure_assembly)
+
+nodes = mesh.nodes
+node_a = int(np.argmin(nodes[:, 0]))
+node_b = int(np.argmax(nodes[:, 0]))
+node_c = int(np.argmax(nodes[:, 1]))
+
+pb.bc.add("Dirichlet", node_a, "Disp", 0)
+pb.bc.add("Dirichlet", node_b, ["DispY", "DispZ"], 0)
+pb.bc.add("Dirichlet", node_c, "DispZ", 0)
+
+pb.nlsolve()
 
 ###############################################################################
 # Extract the results:

--- a/fedoo/constraint/__init__.py
+++ b/fedoo/constraint/__init__.py
@@ -1,5 +1,9 @@
 from .rigid_tie import RigidTie, RigidTie2D
 from .periodic_bc import PeriodicBC
 from .contact import Contact, SelfContact
-from .distributed_load import Pressure, DistributedForce, SurfaceForce
+from .distributed_load import (
+    DistributedForce,
+    Pressure,
+    SurfaceForce,
+)
 from .ipc_contact import IPCContact, IPCSelfContact

--- a/fedoo/constraint/distributed_load.py
+++ b/fedoo/constraint/distributed_load.py
@@ -5,12 +5,80 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 import numpy as np
 from fedoo.core.assembly import Assembly
+from fedoo.core.boundary_conditions import BCBase
 from fedoo.weakform.distributed_load import ExternalPressure, DistributedLoad
 from fedoo.core.mesh import Mesh
 from fedoo.mesh.functions import extract_surface
 
 if TYPE_CHECKING:
     from fedoo.core.base import ProblemBase
+
+
+class _AssemblyNeumannBC(BCBase):
+    """Neumann boundary condition generated from a load assembly.
+
+    The wrapped assembly computes the equivalent nodal load vector, but the
+    vector is injected through ``Problem.B`` like a standard Neumann boundary
+    condition. This keeps distributed loads out of the problem's internal
+    residual assembly during nonlinear solves.
+    """
+
+    def __init__(self, assembly: Assembly, name: str = "", time_func=None):
+        BCBase.__init__(self, name)
+        self.bc_type = "Neumann"
+        self.assembly = assembly
+        self._start_value_default = 0
+        if time_func is None:
+
+            def time_func(t_fact):
+                return t_fact
+
+        self.time_func = time_func
+        self._assembly_t_fact = None
+        self._assembly_vector = None
+
+    def initialize(self, problem: ProblemBase):
+        if self.assembly.mesh.n_nodes != problem.mesh.n_nodes:
+            raise ValueError(
+                "Assembly-based Neumann loads must share the problem mesh nodes."
+            )
+
+        self.assembly.initialize(problem)
+        self._update_during_inc = bool(self.assembly._nlgeom)
+        self._assembly_t_fact = None
+        self._assembly_vector = None
+
+    def _format_current_value(self, problem: ProblemBase, value):
+        if np.isscalar(value) and value == 0:
+            self._dof_index = np.array([], dtype=int)
+            self._current_value = np.array([])
+            return
+
+        if problem.n_global_dof and len(value) < problem.n_dof:
+            value = np.pad(value, (0, problem.n_dof - len(value)))
+        self._dof_index = np.arange(problem.n_dof, dtype=int)
+        self._current_value = value
+
+    def generate(self, problem: ProblemBase, t_fact=1, t_fact_old=None):
+        assembly_t_fact = self.time_func(t_fact)
+        factor_changed = not np.array_equal(self._assembly_t_fact, assembly_t_fact)
+
+        if factor_changed:
+            self.assembly.set_start(problem, t_fact=assembly_t_fact)
+            self._assembly_t_fact = assembly_t_fact
+
+        if self._update_during_inc:
+            self.assembly.update(problem, compute="vector")
+            value = self.assembly.current.get_global_vector()
+        elif factor_changed or self._assembly_vector is None:
+            self.assembly.assemble_global_mat(compute="vector")
+            value = self.assembly.current.get_global_vector()
+            self._assembly_vector = value.copy() if hasattr(value, "copy") else value
+        else:
+            value = self._assembly_vector
+
+        self._format_current_value(problem, value)
+        return [self]
 
 
 class Pressure(Assembly):
@@ -50,6 +118,21 @@ class Pressure(Assembly):
         If not defined, the problem.nlgeom attribute is used instead.
     name: str, optional
         Name of the created assembly.
+    time_func: callable, optional
+        Function that gives the temporal evolution of the pressure when the
+        assembly is converted to a Neumann boundary condition. By default, a
+        linear evolution is considered.
+
+    Notes
+    -----
+    Pressure is an assembly and can still be combined directly with another
+    assembly, for instance ``fd.problem.Linear(solid_assembly + pressure)``.
+    It can also be used as an external Neumann boundary condition with
+    ``pb.bc.add(pressure)`` or ``pb.bc.add(pressure.as_neumann())``. This form
+    is useful for nonlinear problems because the equivalent nodal pressure is
+    included in the external load vector and in residual normalization. When
+    geometrical nonlinearities are active, the follower load is updated during
+    Newton iterations.
 
     Example
     -------
@@ -74,6 +157,10 @@ class Pressure(Assembly):
         pb = fd.problem.Linear(solid_assembly+pressure)
         pb.solve()
 
+        # or add the same pressure as an external Neumann BC
+        pb = fd.problem.NonLinear(solid_assembly, nlgeom=True)
+        pb.bc.add(pressure)
+
         pb.get_results(solid_assembly,'Stress').plot('Stress', 'XX')
     """
 
@@ -84,24 +171,38 @@ class Pressure(Assembly):
         initial_pressure: float | np.ndarray | None = None,
         nlgeom: bool | None = None,
         name: str = "",
+        time_func=None,
     ):
         self.pressure = pressure
         self.initial_pressure = initial_pressure
         self.nlgeom = nlgeom
+        self.time_func = time_func
         wf = ExternalPressure(self.pressure, nlgeom=self.nlgeom)
         Assembly.__init__(self, wf, surface_mesh, name=name)
         if nlgeom == "TL":
             raise NotImplementedError("TL not implemented for distributed loads")
 
-    def set_start(self, pb: ProblemBase):
+    def set_start(self, pb: ProblemBase, t_fact: float | None = None):
         """Start a new time increment."""
+        if t_fact is None:
+            t_fact = pb.t_fact
+
         if self.initial_pressure is None:
-            self.weakform.pressure = pb.t_fact * self.pressure
+            self.weakform.pressure = t_fact * self.pressure
         else:
             self.weakform.pressure = (
-                pb.t_fact * (self.pressure - self.initial_pressure)
-                + self.initial_pressure
+                t_fact * (self.pressure - self.initial_pressure) + self.initial_pressure
             )
+
+    def to_start(self, pb: ProblemBase):
+        """Reset the assembly to the beginning of the time iteration."""
+        self.set_start(pb)
+
+    def as_neumann(self, name: str = "", time_func=None):
+        """Return this pressure load as a Neumann boundary condition."""
+        if time_func is None:
+            time_func = self.time_func
+        return _AssemblyNeumannBC(self, name, time_func=time_func)
 
     @staticmethod
     def from_nodes(
@@ -111,6 +212,7 @@ class Pressure(Assembly):
         initial_pressure: float | np.ndarray | None = None,
         nlgeom: bool | None = None,
         name: str = "",
+        time_func=None,
     ):
         """Create a pressure assembly from a node set.
 
@@ -120,7 +222,9 @@ class Pressure(Assembly):
         See :py:class:`Pressure` for more details on the parameters.
         """
         surface_mesh = extract_surface(mesh, node_set=node_set)
-        return Pressure(surface_mesh, pressure, initial_pressure, nlgeom, name)
+        return Pressure(
+            surface_mesh, pressure, initial_pressure, nlgeom, name, time_func
+        )
 
     @staticmethod
     def from_elements(
@@ -130,6 +234,7 @@ class Pressure(Assembly):
         initial_pressure: float | np.ndarray | None = None,
         nlgeom: bool | None = None,
         name: str = "",
+        time_func=None,
     ):
         """Create a pressure assembly from an element set.
 
@@ -139,7 +244,9 @@ class Pressure(Assembly):
         See :py:class:`Pressure` for more details on the parameters.
         """
         surface_mesh = extract_surface(mesh, element_set=element_set)
-        return Pressure(surface_mesh, pressure, initial_pressure, nlgeom, name)
+        return Pressure(
+            surface_mesh, pressure, initial_pressure, nlgeom, name, time_func
+        )
 
 
 class DistributedForce(Assembly):
@@ -178,6 +285,21 @@ class DistributedForce(Assembly):
         If nlgeom == 'TL' the total lagrangian method is used
     name: str, optional
         Name of the created assembly.
+    time_func: callable, optional
+        Function that gives the temporal evolution of the distributed load when
+        the assembly is converted to a Neumann boundary condition. By default,
+        a linear evolution is considered.
+
+    Notes
+    -----
+    DistributedForce is an assembly and can still be combined directly with
+    another assembly, for instance
+    ``fd.problem.Linear(solid_assembly + volume_force)``. It can also be used
+    as an external Neumann boundary condition with ``pb.bc.add(volume_force)``
+    or ``pb.bc.add(volume_force.as_neumann())``. This form is useful for
+    nonlinear problems because the equivalent nodal force is included in the
+    external load vector and in residual normalization. When geometrical
+    nonlinearities are active, the load is updated during Newton iterations.
 
     Example
     -------
@@ -198,10 +320,14 @@ class DistributedForce(Assembly):
         volume_force = fd.constraint.DistributedForce(
             mesh, [0,0,-1000], nlgeom=False)
 
-        # define a problem from the solid and pressure assemblies
+        # define a problem from the solid and volume-force assemblies
         pb = fd.problem.Linear(solid_assembly+volume_force)
         pb.bc.add('Dirichlet', 'bottom', 'Disp', 0)
         pb.solve()
+
+        # or add the same force as an external Neumann BC
+        pb = fd.problem.NonLinear(solid_assembly, nlgeom=True)
+        pb.bc.add(volume_force)
 
         pb.get_results(solid_assembly,'Stress').plot('Stress', 'XX', 'Node')
     """
@@ -213,6 +339,7 @@ class DistributedForce(Assembly):
         initial_force: np.typing.ArrayLike[float] | None = None,
         nlgeom: bool | None = None,
         name: str = "",
+        time_func=None,
     ):
         self.force = force
         if initial_force is not None:
@@ -220,32 +347,42 @@ class DistributedForce(Assembly):
         else:
             self.initial_force = None
         self.nlgeom = nlgeom
+        self.time_func = time_func
         wf = DistributedLoad(self.force, nlgeom=self.nlgeom)
         Assembly.__init__(self, wf, mesh, name=name)
 
-    def set_start(self, pb: ProblemBase):
+    def set_start(self, pb: ProblemBase, t_fact: float | None = None):
         """Start a new time increment."""
+        if t_fact is None:
+            t_fact = pb.t_fact
+
         if self.initial_force is None:
             if isinstance(self.force, np.ndarray):
-                self.weakform.distributed_force = pb.t_fact * self.force
+                self.weakform.distributed_force = t_fact * self.force
             else:
-                self.weakform.distributed_force = [pb.t_fact * f for f in self.force]
+                self.weakform.distributed_force = [t_fact * f for f in self.force]
         else:
             if isinstance(self.force, np.ndarray) and isinstance(
                 self.initial_force, np.ndarray
             ):
                 self.weakform.distributed_force = (
-                    pb.t_fact * (self.force - self.initial_force) + self.initial_force
+                    t_fact * (self.force - self.initial_force) + self.initial_force
                 )
             else:
                 self.weakform.distributed_force = [
-                    pb.t_fact * (f - self.initial_force[i]) + self.initial_force[i]
+                    t_fact * (f - self.initial_force[i]) + self.initial_force[i]
                     for i, f in enumerate(self.force)
                 ]
 
     def to_start(self, pb: ProblemBase):
-        """Reset the assembly to the begining of the time iteration."""
+        """Reset the assembly to the beginning of the time iteration."""
         self.set_start(pb)
+
+    def as_neumann(self, name: str = "", time_func=None):
+        """Return this distributed load as a Neumann boundary condition."""
+        if time_func is None:
+            time_func = self.time_func
+        return _AssemblyNeumannBC(self, name, time_func=time_func)
 
 
 class SurfaceForce(DistributedForce):
@@ -265,6 +402,7 @@ class SurfaceForce(DistributedForce):
         initial_force: np.typing.ArrayLike[float] | None = None,
         nlgeom: bool | None = None,
         name: str = "",
+        time_func=None,
     ):
         """Create a SurfaceForce assembly from an node set.
 
@@ -274,7 +412,9 @@ class SurfaceForce(DistributedForce):
         See :py:class:`SurfaceForce` for more details on the parameters.
         """
         surface_mesh = extract_surface(mesh, node_set=node_set)
-        return DistributedForce(surface_mesh, force, initial_force, nlgeom, name)
+        return DistributedForce(
+            surface_mesh, force, initial_force, nlgeom, name, time_func
+        )
 
     @staticmethod
     def from_elements(
@@ -284,6 +424,7 @@ class SurfaceForce(DistributedForce):
         initial_force: np.typing.ArrayLike[float] | None = None,
         nlgeom: bool | None = None,
         name: str = "",
+        time_func=None,
     ):
         """Create a SurfaceForce assembly from an element set.
 
@@ -293,4 +434,6 @@ class SurfaceForce(DistributedForce):
         See :py:class:`SurfaceForce` for more details on the parameters.
         """
         surface_mesh = extract_surface(mesh, element_set=element_set)
-        return DistributedForce(surface_mesh, force, initial_force, nlgeom, name)
+        return DistributedForce(
+            surface_mesh, force, initial_force, nlgeom, name, time_func
+        )

--- a/fedoo/core/assembly.py
+++ b/fedoo/core/assembly.py
@@ -1636,9 +1636,11 @@ class Assembly(AssemblyBase):
                 for i, wf in enumerate(list_weakform)
             ]
             list_prop = list(zip(list_n_elm_gp, list_assume_sym, list_elm_type))
-            list_diff_prop = list(
-                set(list_prop)
-            )  # list of different non compatible properties that required separated assembly
+            list_diff_prop = []
+            for prop in list_prop:
+                if prop not in list_diff_prop:
+                    list_diff_prop.append(prop)
+            # list of different non compatible properties that require separated assembly
 
             if len(list_diff_prop) == 1:  # only 1 assembly is required
                 # update assembly_options

--- a/fedoo/core/boundary_conditions.py
+++ b/fedoo/core/boundary_conditions.py
@@ -169,6 +169,7 @@ class ListBC(BCBase):
         * ListBC.add(bc), where bc is any BC object.
 
           Add the object bc at the end of the list. (equivalent to ListBC.append(bc))
+          If bc provides an as_neumann() method, it is converted first.
 
         * ListBC.add(bc_type, node_set, variable, value, time_func=None, start_value=None, name=""):
 
@@ -182,8 +183,20 @@ class ListBC(BCBase):
           If a variable contains only one dof, the node_set parameter can be skiped.
         """
         if len(args) == 1:  # assume arg[0] is a boundary condition object
-            self.append(args[0])
-            return args[0]
+            bc = args[0]
+            if hasattr(bc, "assemble_global_mat") and hasattr(bc, "current"):
+                # Assembly object
+                if hasattr(bc, "as_neumann"):
+                    bc = bc.as_neumann()
+                else:
+                    raise TypeError(
+                        "Assembly objects added to a boundary-condition list must "
+                        "provide an as_neumann() method. Add the assembly to the "
+                        "problem assembly directly, or use an assembly type that can "
+                        "be converted to a Neumann boundary condition."
+                    )
+            self.append(bc)
+            return bc
         else:  # define a boundary condition
             type_bc = args[0]
             if len(args) == 3 and (
@@ -462,21 +475,13 @@ class BoundaryCondition(BCBase):
             # must be a string defining a set of nodes
             self.node_set = problem.mesh.node_sets[self.node_set_name]
 
-        if hasattr(problem.mesh, "GetListMesh"):  # associated to pgd problem
-            self.pgd = True
-        else:
-            self.pgd = False
-            # must be a np.array  #Not for PGD
-            self.node_set = np.asarray(self.node_set, dtype=int)
+        self.node_set = np.asarray(self.node_set, dtype=int)
 
     def generate(self, problem, t_fact, t_fact_old=None):
         self._current_value = self.get_value(t_fact, t_fact_old)
-
-        if not (self.pgd):
-            self._dof_index = (
-                self.variable * problem.mesh.n_nodes + self.node_set
-            ).astype(int)
-
+        self._dof_index = (self.variable * problem.mesh.n_nodes + self.node_set).astype(
+            int
+        )
         return [self]
 
     def _get_factor(self, t_fact=1, t_fact_old=None):
@@ -666,12 +671,8 @@ class MPC(BCBase):
                     ] + problem.global_dof.indice_start(var)
                     self.list_variables[i] = problem.space.nvar
 
-        if hasattr(problem.mesh, "GetListMesh"):  # associated to pgd problem
-            self.pgd = True
-        else:
-            self.pgd = False
-            self.list_node_sets = np.asarray(self.list_node_sets, dtype=int)
-            self.list_variables = np.asarray(self.list_variables, dtype=int)
+        self.list_node_sets = np.asarray(self.list_node_sets, dtype=int)
+        self.list_variables = np.asarray(self.list_variables, dtype=int)
 
     def generate(self, problem, t_fact, t_fact_old=None):
         # # Node index for master DOF (not eliminated DOF in MPC)

--- a/fedoo/weakform/distributed_load.py
+++ b/fedoo/weakform/distributed_load.py
@@ -20,8 +20,10 @@ class ExternalPressure(WeakFormBase):
     This weak formulation permit to define pressure load and
     should be associated to another weak formulation (e.g. StressEquilibrium).
 
-    The easiest way to define a pressure load is to directly
-    build the corresponding assembly with :py:meth:`fd.constraint.Pressure`.
+    The recommended way to apply a pressure load is to build the corresponding
+    assembly with :py:meth:`fd.constraint.Pressure` and add it to the problem
+    boundary conditions with ``pb.bc.add(pressure_assembly)``. The assembly is
+    then converted to an equivalent Neumann boundary condition.
     """
 
     def __init__(
@@ -113,10 +115,11 @@ class DistributedLoad(WeakFormBase):
     This weak formulation permit to define distributed loads and
     should be associated to another weak formulation (e.g. StressEquilibrium).
 
-    The easiest way to define a distributed load is to directly
-    build the corresponding assembly with
-    :py:meth:`fd.constraint.DistributedForce` or
-    :py:meth:`fd.constraint.SurfaceForce`.
+    The recommended way to apply a distributed load is to build the
+    corresponding assembly with :py:meth:`fd.constraint.DistributedForce` or
+    :py:meth:`fd.constraint.SurfaceForce` and add it to the problem boundary
+    conditions with ``pb.bc.add(load_assembly)``. The assembly is then
+    converted to an equivalent Neumann boundary condition.
     """
 
     def __init__(self, distributed_force: list, name="", nlgeom=False, space=None):

--- a/fedoo/weakform/stress_equilibrium_bbar.py
+++ b/fedoo/weakform/stress_equilibrium_bbar.py
@@ -506,10 +506,10 @@ class HourglassStiffness(WeakFormBase):
         super().initialize(assembly, pb)
         self._initialize_nlgeom(assembly, pb)
         if self.compute_stiffness_only_once is None:
-            if assembly._nlgeom:
-                self.compute_stiffness_only_once = False
-            else:
-                self.compute_stiffness_only_once = True
+            is_nonlinear_problem = pb.__class__.__name__.lower().startswith("nonlinear")
+            self.compute_stiffness_only_once = not (
+                assembly._nlgeom or is_nonlinear_problem
+            )
 
         assembly.stress_equilibrium_assembly = (
             self.stress_equilibrium_assembly
@@ -539,6 +539,13 @@ class HourglassStiffness(WeakFormBase):
         if assembly._nlgeom == "UL":
             # if updated lagragian method
             # -> update the mesh and recompute elementary op
+            assembly.set_disp(pb.get_disp())
+
+    def to_start(self, assembly, pb):
+        """Reset the current time increment."""
+        if assembly._nlgeom == "UL":
+            # if updated lagrangian method -> reset the mesh to the begining
+            # of the increment
             assembly.set_disp(pb.get_disp())
 
     def get_p_wave_modulus(self, assembly):

--- a/tests/test_distributed_load_neumann_bc.py
+++ b/tests/test_distributed_load_neumann_bc.py
@@ -17,9 +17,7 @@ def _build_problem(load_nlgeom=None, problem_nlgeom=True, load_kind="pressure"):
 
     if load_kind == "pressure":
         top = mesh.find_nodes("Z", mesh.bounding_box.zmax)
-        load = fd.constraint.Pressure.from_nodes(
-            mesh, top, 7.0, nlgeom=load_nlgeom
-        )
+        load = fd.constraint.Pressure.from_nodes(mesh, top, 7.0, nlgeom=load_nlgeom)
     elif load_kind == "distributed":
         load = fd.constraint.DistributedForce(
             mesh, [0.0, 0.0, -7.0], nlgeom=load_nlgeom
@@ -28,9 +26,9 @@ def _build_problem(load_nlgeom=None, problem_nlgeom=True, load_kind="pressure"):
         raise ValueError(load_kind)
 
     bc = pb.bc.add(load)
-    assert isinstance(bc, fd.constraint.AssemblyNeumannBC)
+    assert bc.bc_type == "Neumann"
+    assert bc.assembly is load
     return pb, bc
-
 
 
 def test_assembly_neumann_load_can_still_be_added_explicitly():
@@ -40,6 +38,42 @@ def test_assembly_neumann_load_can_still_be_added_explicitly():
     explicit_bc = bc.assembly.as_neumann()
 
     assert pb.bc.add(explicit_bc) is explicit_bc
+
+
+@pytest.mark.parametrize("load_kind", ["pressure", "distributed", "surface"])
+def test_assembly_neumann_load_uses_stored_time_function(load_kind):
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("3D")
+
+    mesh = fd.mesh.box_mesh(2, 2, 2, name="stored_time_func_box")
+    material = fd.constitutivelaw.ElasticIsotrop(1000.0, 0.3, name="TimeFuncMat")
+    wf = fd.weakform.StressEquilibrium(material)
+    solid = fd.Assembly.create(wf, mesh, name="time_func_solid")
+    pb = fd.problem.NonLinear(solid, nlgeom=False)
+    top = mesh.find_nodes("Z", mesh.bounding_box.zmax)
+
+    if load_kind == "pressure":
+        load = fd.constraint.Pressure.from_nodes(
+            mesh, top, 7.0, nlgeom=False, time_func=lambda t: t**2
+        )
+    elif load_kind == "distributed":
+        load = fd.constraint.DistributedForce(
+            mesh, [0.0, 0.0, -7.0], nlgeom=False, time_func=lambda t: t**2
+        )
+    else:
+        load = fd.constraint.SurfaceForce.from_nodes(
+            mesh, top, [0.0, 0.0, -7.0], nlgeom=False, time_func=lambda t: t**2
+        )
+
+    pb.bc.add(load)
+    pb.apply_boundary_conditions(t_fact=0.5, t_fact_old=0.0)
+    quarter_load = pb.get_B().copy()
+
+    pb.apply_boundary_conditions(t_fact=1.0, t_fact_old=0.5)
+    full_load = pb.get_B().copy()
+
+    assert np.linalg.norm(full_load) > 0.0
+    np.testing.assert_allclose(quarter_load, 0.25 * full_load)
 
 
 def test_assembly_neumann_load_accepts_time_function_and_caches_fixed_vector():
@@ -88,9 +122,7 @@ def test_raw_assembly_without_neumann_conversion_is_rejected():
 
 @pytest.mark.parametrize("load_kind", ["pressure", "distributed"])
 def test_assembly_neumann_load_is_ramped_in_external_force_vector(load_kind):
-    pb, _ = _build_problem(
-        load_nlgeom=False, problem_nlgeom=True, load_kind=load_kind
-    )
+    pb, _ = _build_problem(load_nlgeom=False, problem_nlgeom=True, load_kind=load_kind)
 
     pb.apply_boundary_conditions(t_fact=0.5, t_fact_old=0.0)
     half_load = pb.get_B().copy()

--- a/tests/test_distributed_load_neumann_bc.py
+++ b/tests/test_distributed_load_neumann_bc.py
@@ -1,0 +1,125 @@
+import numpy as np
+import pytest
+from scipy import sparse
+
+import fedoo as fd
+
+
+def _build_problem(load_nlgeom=None, problem_nlgeom=True, load_kind="pressure"):
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("3D")
+
+    mesh = fd.mesh.box_mesh(2, 2, 2, name="load_box")
+    material = fd.constitutivelaw.ElasticIsotrop(1000.0, 0.3, name="LoadMat")
+    wf = fd.weakform.StressEquilibrium(material)
+    solid = fd.Assembly.create(wf, mesh, name="solid")
+    pb = fd.problem.NonLinear(solid, nlgeom=problem_nlgeom)
+
+    if load_kind == "pressure":
+        top = mesh.find_nodes("Z", mesh.bounding_box.zmax)
+        load = fd.constraint.Pressure.from_nodes(
+            mesh, top, 7.0, nlgeom=load_nlgeom
+        )
+    elif load_kind == "distributed":
+        load = fd.constraint.DistributedForce(
+            mesh, [0.0, 0.0, -7.0], nlgeom=load_nlgeom
+        )
+    else:
+        raise ValueError(load_kind)
+
+    bc = pb.bc.add(load)
+    assert isinstance(bc, fd.constraint.AssemblyNeumannBC)
+    return pb, bc
+
+
+
+def test_assembly_neumann_load_can_still_be_added_explicitly():
+    pb, bc = _build_problem(load_nlgeom=False, problem_nlgeom=False)
+
+    pb.bc.remove(bc)
+    explicit_bc = bc.assembly.as_neumann()
+
+    assert pb.bc.add(explicit_bc) is explicit_bc
+
+
+def test_assembly_neumann_load_accepts_time_function_and_caches_fixed_vector():
+    pb, bc = _build_problem(load_nlgeom=False, problem_nlgeom=False)
+    pb.bc.remove(bc)
+
+    load = bc.assembly
+    bc = pb.bc.add(load.as_neumann(time_func=lambda t: t**2))
+    assemble_global_mat = load.assemble_global_mat
+    call_count = 0
+
+    def counted_assemble_global_mat(compute="all"):
+        nonlocal call_count
+        call_count += 1
+        return assemble_global_mat(compute)
+
+    load.assemble_global_mat = counted_assemble_global_mat
+
+    pb.apply_boundary_conditions(t_fact=0.5, t_fact_old=0.0)
+    quarter_load = pb.get_B().copy()
+
+    pb.apply_boundary_conditions(t_fact=0.5, t_fact_old=0.0)
+    quarter_load_again = pb.get_B().copy()
+
+    pb.apply_boundary_conditions(t_fact=1.0, t_fact_old=0.5)
+    full_load = pb.get_B().copy()
+
+    assert call_count == 2
+    np.testing.assert_allclose(quarter_load_again, quarter_load)
+    np.testing.assert_allclose(quarter_load, 0.25 * full_load)
+
+
+def test_raw_assembly_without_neumann_conversion_is_rejected():
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("3D")
+
+    mesh = fd.mesh.box_mesh(2, 2, 2, name="raw_assembly_box")
+    material = fd.constitutivelaw.ElasticIsotrop(1000.0, 0.3, name="RawMat")
+    wf = fd.weakform.StressEquilibrium(material)
+    solid = fd.Assembly.create(wf, mesh, name="raw_solid")
+    pb = fd.problem.NonLinear(solid, nlgeom=False)
+
+    with pytest.raises(TypeError, match="as_neumann"):
+        pb.bc.add(solid)
+
+
+@pytest.mark.parametrize("load_kind", ["pressure", "distributed"])
+def test_assembly_neumann_load_is_ramped_in_external_force_vector(load_kind):
+    pb, _ = _build_problem(
+        load_nlgeom=False, problem_nlgeom=True, load_kind=load_kind
+    )
+
+    pb.apply_boundary_conditions(t_fact=0.5, t_fact_old=0.0)
+    half_load = pb.get_B().copy()
+
+    pb.apply_boundary_conditions(t_fact=1.0, t_fact_old=0.5)
+    full_load = pb.get_B().copy()
+
+    assert np.linalg.norm(full_load) > 0.0
+    np.testing.assert_allclose(half_load, 0.5 * full_load)
+
+
+def test_assembly_neumann_load_updates_during_increment_only_for_nlgeom():
+    _, inherited = _build_problem(load_nlgeom=None, problem_nlgeom=True)
+    _, fixed = _build_problem(load_nlgeom=False, problem_nlgeom=True)
+    _, small_strain = _build_problem(load_nlgeom=None, problem_nlgeom=False)
+
+    assert inherited._update_during_inc is True
+    assert fixed._update_during_inc is False
+    assert small_strain._update_during_inc is False
+
+
+def test_assembly_neumann_load_is_ignored_by_standard_start_value_update():
+    pb, _ = _build_problem(load_nlgeom=False, problem_nlgeom=False)
+
+    pb.initialize()
+    pb.apply_boundary_conditions(t_fact=1.0, t_fact_old=0.0)
+    pb._U = np.ones(pb.n_dof)
+    pb.set_X(np.zeros(pb.n_dof))
+    pb.set_A(sparse.identity(pb.n_dof, format="csr"))
+    pb.set_D(0)
+
+    pb.init_bc_start_value()


### PR DESCRIPTION
This PR changes the recommended handling of pressure and distributed loads so they can be added directly through the problem boundary-condition list:

```python
pressure = fd.constraint.Pressure(surface_mesh, value, nlgeom=True)

pb = fd.problem.NonLinear(solid_assembly, nlgeom=True)
pb.bc.add(pressure)
```

Assemblies that expose as_neumann() are automatically converted by pb.bc.add(...) to an equivalent Neumann boundary condition. Raw assemblies without as_neumann() now raise a clear error when passed to pb.bc.add(...).
This is mainly useful for nonlinear analyses: distributed loads are now included in the external force vector, follow the load coefficient or their own time_func during increments, and participate correctly in automatic residual normalization. Follower loads with nlgeom=True are still updated during Newton iterations.

Main changes:
- Added a private _AssemblyNeumannBC wrapper for load assemblies.
- Added as_neumann() support for Pressure and DistributedForce.
- Added time_func support to Pressure, DistributedForce, and SurfaceForce factory methods, automatically passed to the Neumann wrapper.
- Updated ListBC.add() to accept compatible assembly-based Neumann loads.
- Preserved the old solid_assembly + pressure_assembly usage as an alternative, but documented it as less suitable for nonlinear analyses.
- Updated the spherical shell compression example to use the new load path.
- Updated documentation and weakform docstrings to recommend pb.bc.add(load_assembly).
- Added regression tests for automatic conversion, explicit .as_neumann() usage, load ramping, custom and stored time_func, nlgeom update behavior, and rejection of unsupported raw assemblies.