### PR TITLE
Add quadratic reduced-integration 3D elements (hex20r, tet10r)

### DIFF
--- a/fedoo/lib_elements/__init__.py
+++ b/fedoo/lib_elements/__init__.py
@@ -42,11 +42,11 @@ from .finite_difference_1d import (
     Node,
     Parameter,
 )
-from .hexahedron import ElementHexahedron, Hex8, Hex20, Hex8r
+from .hexahedron import ElementHexahedron, Hex8, Hex20, Hex20r, Hex8r
 from .line import Lin2, Lin2Bubble, Lin3, Lin3Bubble
 from .plate import pquad4, pquad8, pquad9, ptri3, ptri6
 from .quadrangle import ElementQuadrangle, Quad4, Quad8, Quad9
-from .tetrahedron import ElementTetrahedron, Tet4, Tet10
+from .tetrahedron import ElementTetrahedron, Tet4, Tet10, Tet10r
 from .triangle import ElementTriangle, Tri3, Tri3Bubble, Tri6
 from .wedge import ElementWedge, Wed6, Wed15, Wed18
 from .incompressible import hex8sri
@@ -90,7 +90,9 @@ __all__ = [
     "Parameter",
     "ElementHexahedron",
     "Hex8",
+    "Hex8r",
     "Hex20",
+    "Hex20r",
     "Lin2",
     "Lin2Bubble",
     "Lin3",
@@ -107,6 +109,7 @@ __all__ = [
     "ElementTetrahedron",
     "Tet4",
     "Tet10",
+    "Tet10r",
     "ElementTriangle",
     "Tri3",
     "Tri3Bubble",

--- a/fedoo/lib_elements/element_list.py
+++ b/fedoo/lib_elements/element_list.py
@@ -3,7 +3,7 @@ from fedoo.lib_elements.finite_difference_1d import Node, Parameter
 
 # from fedoo.lib_elements.beam import *
 # from fedoo.lib_elements.cohesive import Cohesive1D
-from fedoo.lib_elements.hexahedron import Hex8, Hex20, Hex8r, Hex8Hourglass
+from fedoo.lib_elements.hexahedron import Hex8, Hex20, Hex20r, Hex8r, Hex8Hourglass
 from fedoo.lib_elements.line import Lin2, Lin2Bubble, Lin3, Lin3Bubble
 from fedoo.lib_elements.quadrangle import (
     Quad4,
@@ -14,7 +14,7 @@ from fedoo.lib_elements.quadrangle import (
 )
 
 # from fedoo.lib_elements.plate import *
-from fedoo.lib_elements.tetrahedron import Tet4, Tet10
+from fedoo.lib_elements.tetrahedron import Tet4, Tet10, Tet10r
 from fedoo.lib_elements.triangle import Tri3, Tri3r, Tri3Bubble, Tri6
 from fedoo.lib_elements.wedge import Wed6, Wed15, Wed18
 
@@ -35,10 +35,12 @@ _dict_elements = {
     "quad9": Quad9,
     "tet4": Tet4,
     "tet10": Tet10,
+    "tet10r": Tet10r,
     "hex8": Hex8,
     "hex8r": Hex8r,
     "hex8hourglass": Hex8Hourglass,
     "hex20": Hex20,
+    "hex20r": Hex20r,
     "wed6": Wed6,
     "wed15": Wed15,
     "wed18": Wed18,
@@ -64,9 +66,11 @@ _dict_default_n_gp = {
     "quad9": 9,
     "tet4": 4,
     "tet10": 15,
+    "tet10r": 4,
     "hex8": 8,
     "hex8r": 1,
     "hex20": 27,
+    "hex20r": 14,
     "wed6": 6,
     "wed15": 21,
     "wed18": 21,
@@ -124,7 +128,7 @@ def get_node_elm_coordinates(element, nNd_elm=None):
                 [-1.0, 1.0, 1.0, -1.0, -1.0, 1.0, 1.0, -1.0],
                 [-1.0, -1.0, 1.0, 1.0, -1.0, -1.0, 1.0, 1.0],
             ]
-    elif element in ["tet4", "tet10"]:
+    elif element in ["tet4", "tet10", "tet10r"]:
         if nNd_elm == 4:
             return np.c_[
                 [0.0, 0.0, 0.0, 1.0], [1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]
@@ -135,7 +139,7 @@ def get_node_elm_coordinates(element, nNd_elm=None):
                 [1.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.5, 0.5, 0.0, 0.0],
                 [0.0, 1.0, 0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.5, 0.0],
             ]
-    elif element in ["hex8", "hex20", "hex8r"]:
+    elif element in ["hex8", "hex20", "hex8r", "hex20r"]:
         if nNd_elm == 8:
             return np.c_[
                 [-1.0, 1.0, 1.0, -1.0, -1.0, 1.0, 1.0, -1.0],

--- a/fedoo/lib_elements/hexahedron.py
+++ b/fedoo/lib_elements/hexahedron.py
@@ -121,6 +121,30 @@ class ElementHexahedron(Element):
                 ]
             ]
             return np.c_[xi, eta, zeta]
+        elif n_elm_gp == 14:
+            # 14-point reduced integration rule for the 20-node hexahedron
+            # (Ansys SOLID186 uniform reduced integration, Irons rule).
+            # 6 points on the axes at +/- b and 8 corner points at +/- c.
+            b = 0.7958224257542215  # np.sqrt(19.0 / 30.0)
+            c = 0.7587869106393281  # np.sqrt(19.0 / 33.0)
+            return np.array(
+                [
+                    [-b, 0.0, 0.0],
+                    [b, 0.0, 0.0],
+                    [0.0, -b, 0.0],
+                    [0.0, b, 0.0],
+                    [0.0, 0.0, -b],
+                    [0.0, 0.0, b],
+                    [-c, -c, -c],
+                    [-c, -c, c],
+                    [-c, c, -c],
+                    [-c, c, c],
+                    [c, -c, -c],
+                    [c, -c, c],
+                    [c, c, -c],
+                    [c, c, c],
+                ]
+            )
         else:
             assert 0, (
                 "Number of gauss points "
@@ -167,6 +191,12 @@ class ElementHexahedron(Element):
                     b**3,
                 ]
             )
+        elif n_elm_gp == 14:
+            # weights for the 14-point reduced integration rule (Irons rule).
+            # 320/361 for the 6 axis points, 121/361 for the 8 corner points.
+            wb = 0.8864265927977839  # 320.0 / 361.0
+            wc = 0.3351800554016620  # 121.0 / 361.0
+            return np.array([wb, wb, wb, wb, wb, wb, wc, wc, wc, wc, wc, wc, wc, wc])
         else:
             assert 0, (
                 "Number of gauss points "
@@ -486,6 +516,17 @@ class Hex20(ElementHexahedron):
             )
             for xi in vec_xi
         ]
+
+
+class Hex20r(Hex20):
+    name = "hex20r"
+    default_n_gp = 14
+    n_nodes = 20
+
+    # Same 20-node quadratic interpolation as Hex20, but integrated with the
+    # 14-point reduced rule (Ansys SOLID186 uniform reduced integration).
+    def __init__(self, n_elm_gp=14, **kargs):
+        Hex20.__init__(self, n_elm_gp, **kargs)
 
 
 #### Hourglass control shape function ####

--- a/fedoo/lib_elements/tetrahedron.py
+++ b/fedoo/lib_elements/tetrahedron.py
@@ -206,3 +206,16 @@ class Tet10(ElementTetrahedron):
             )
             for m, xi in zip(vec_m, vec_xi)
         ]
+
+
+class Tet10r(Tet10):
+    name = "tet10r"
+    default_n_gp = 4
+    n_nodes = 10
+
+    # Same 10-node quadratic interpolation as Tet10, but integrated with the
+    # 4-point rule instead of the default accurate 15-point rule. This matches
+    # the integration scheme of the Ansys SOLID187 tetrahedron and is cheaper
+    # while remaining stable (a 1-point rule would be rank deficient).
+    def __init__(self, n_elm_gp=4, **kargs):
+        Tet10.__init__(self, n_elm_gp, **kargs)


### PR DESCRIPTION
Add reduced-integration variants of the quadratic solid elements, following the Ansys integration schemes:

- hex20r: 20-node hexahedron with the 14-point uniform reduced integration rule (Irons rule, Ansys SOLID186). Same quadratic interpolation as hex20, integrated at 14 Gauss points instead of 27. The rule is 5th-order accurate and rank-sufficient (no hourglassing).
- tet10r: 10-node tetrahedron integrated with the 4-point rule (Ansys SOLID187 scheme) instead of the default 15-point rule. A 1-point rule would be rank deficient, so 4 points is used as the stable reduced scheme.

The 14-point rule is added to ElementHexahedron; the 4-point rule already existed for tetrahedra. Both elements are registered in element_list (dict + default n_gp + node-coordinate geometry lists) and exported from lib_elements.

Verified: 14-point rule integrates polynomials of total degree <= 5 exactly; both elements assemble, solve, and support Gauss-point-to-node stress recovery in 3D elasticity; existing 3D tests still pass.