### PR TITLE
Refactor LagrangeMultiplier and add mean-value test

### DIFF
--- a/fedoo/constraint/mean_value_constraint.py
+++ b/fedoo/constraint/mean_value_constraint.py
@@ -194,7 +194,6 @@ class MeanValueConstraint(LagrangeMultiplierAssembly):
         self._var_names = variables
         self._ranks = [self.space.variable_rank(var) for var in variables]
         self._weights = weights
-        self._lm_names = [f"{self.name}_{variable}" for variable in variables]
 
         node_terms = [[int(node)] for node in nodes]
         factor_terms = [float(weight) for weight in weights]
@@ -209,5 +208,5 @@ class MeanValueConstraint(LagrangeMultiplierAssembly):
                 for variable, value in zip(variables, values)
             ]
         )
-        self.multiplier_names = self._lm_names
+        self.multiplier_names = [f"{self.name}_{variable}" for variable in variables]
         super().initialize(pb)

--- a/fedoo/core/lagrange_multiplier.py
+++ b/fedoo/core/lagrange_multiplier.py
@@ -19,6 +19,28 @@ class LagrangeMultiplierAssembly(AssemblyBase):
     method produces only MPC leaves, or an iterable of such objects. Wrapped
     constraints must not also be added to the problem boundary conditions,
     since that would enforce them a second time through elimination.
+
+    Parameters
+    ----------
+    mesh: fedoo.Mesh
+        Mesh associated with the constraint. It should share the nodes of the
+        assembly with which this constraint is summed.
+    constraints: MPC, ListBC, BC object or iterable of BC objects
+        Constraint(s) to enforce. Any wrapped object must generate only
+        :py:class:`fedoo.MPC` leaves.
+    name: str, default = "LagrangeMultiplier"
+        Assembly name. It is also the name of the global vector that gathers
+        the Lagrange-multiplier DOFs.
+    multiplier_names: list of str or None, default = None
+        Names of the multiplier DOFs, one per generated equation. If None, the
+        multipliers are gathered as a single global vector named ``name``.
+    space: ModelingSpace, optional
+        Modeling space. If None, the active modeling space is used.
+
+    Notes
+    -----
+    The multipliers give the system a zero diagonal block and an indefinite
+    saddle-point structure, so a direct solver is required.
     """
 
     def __init__(
@@ -50,7 +72,6 @@ class LagrangeMultiplierAssembly(AssemblyBase):
         self._registered_pbs = []
         self._equation_dofs = None
         self._equation_coefficients = None
-        self._constraint_values = None
 
     def __repr__(self):
         return (
@@ -67,7 +88,11 @@ class LagrangeMultiplierAssembly(AssemblyBase):
 
     def _collect_equations(self, pb):
         t_fact, t_fact_old = self._time_factors(pb)
-        generated = list(self.constraints.generate(pb, t_fact, t_fact_old))
+        # Non-incremental constraints express the LM residual with the total
+        # solution, not its increment, so they are generated with no previous
+        # time factor.
+        gen_t_fact_old = t_fact_old if self._incremental_equations else None
+        generated = list(self.constraints.generate(pb, t_fact, gen_t_fact_old))
         if not generated:
             raise ValueError(
                 "The wrapped boundary-condition object generated no constraints."
@@ -82,9 +107,6 @@ class LagrangeMultiplierAssembly(AssemblyBase):
                     "LagrangeMultiplierAssembly only accepts BC objects whose "
                     f"generated leaves are MPCs; got {type(constraint).__name__}."
                 )
-            if t_fact_old is not None and not self._incremental_equations:
-                # The LM residual uses the total solution, not its increment.
-                constraint.generate(pb, t_fact, None)
             dofs, coefficients, current_values = constraint.get_generated_equations()
             for dof_row, coefficient_row, value in zip(
                 dofs, coefficients, current_values
@@ -107,7 +129,7 @@ class LagrangeMultiplierAssembly(AssemblyBase):
             # driver values while generating their equations. Boundary
             # conditions have not been applied yet during assembly setup.
             pb._Xbc = np.zeros(pb.n_dof)
-        dofs, coefficients, values = self._collect_equations(pb)
+        dofs, coefficients, _ = self._collect_equations(pb)
         n_constraints = len(dofs)
 
         if self.multiplier_names is None:
@@ -144,7 +166,6 @@ class LagrangeMultiplierAssembly(AssemblyBase):
         self._n_constraints = n_constraints
         self._equation_dofs = dofs
         self._equation_coefficients = coefficients
-        self._constraint_values = values
         self.delete_global_mat()
 
     def _register_global_dofs(self, pb):
@@ -234,10 +255,8 @@ class LagrangeMultiplierAssembly(AssemblyBase):
                 "initialization; multiplier DOFs cannot be resized safely."
             )
 
-        matrix_changed = self._equations_changed(dofs, coefficients)
         if (
-            compute != "vector"
-            or matrix_changed
+            self._equations_changed(dofs, coefficients)
             or self.global_matrix is None
             or self.global_matrix.shape != (n_dof, n_dof)
         ):
@@ -245,7 +264,6 @@ class LagrangeMultiplierAssembly(AssemblyBase):
 
         self._equation_dofs = dofs
         self._equation_coefficients = coefficients
-        self._constraint_values = values
 
         if compute != "matrix":
             self.global_vector = self._assemble_vector(pb, n_dof, values)
@@ -268,4 +286,3 @@ class LagrangeMultiplierAssembly(AssemblyBase):
         self.delete_global_mat()
         self._equation_dofs = None
         self._equation_coefficients = None
-        self._constraint_values = None

--- a/tests/test_mean_value_constraint.py
+++ b/tests/test_mean_value_constraint.py
@@ -111,6 +111,29 @@ def test_mean_disp_constraint_nonlinear():
     assert np.abs(disp.mean(axis=1)).max() < 1e-8
 
 
+def test_mean_disp_constraint_nonzero_value():
+    """A nonzero prescribed mean value is enforced with the correct sign: the
+    raw value is used as the constraint right-hand side, so mean(u) == value
+    (not -value). The value=0 tests cannot catch a sign error here."""
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("2Dstress")
+
+    mesh = fd.mesh.hole_plate_mesh(nr=5, nt=5, length=10, height=10, radius=2)
+    material = fd.constitutivelaw.ElasticIsotrop(1e5, 0.3)
+    wf = fd.weakform.StressEquilibrium(material)
+    assemb = fd.Assembly.create(wf, mesh)
+
+    target = np.array([0.02, -0.01])
+    constraint = fd.constraint.MeanValueConstraint(mesh, "Disp", value=target)
+    pb = fd.problem.Linear(assemb + constraint)
+
+    pb.bc.add(fd.constraint.PeriodicBC(periodicity_type="small_strain"))
+    pb.bc.add("Dirichlet", "MeanStrain", [0.1, 0.05, 0.02])
+    pb.solve()
+
+    assert np.allclose(pb.get_disp().mean(axis=1), target, atol=1e-10)
+
+
 def test_mean_disp_constraint_volume_weights():
     """With weights="volume", the volume average of the displacement field
     should be zero."""


### PR DESCRIPTION
Adjust LagrangeMultiplierAssembly to properly handle non-incremental constraints by passing None as the old time factor when appropriate (avoids double-generation and incorrect residuals). Remove persistent _constraint_values state and simplify equation-change checks and vector/matrix assembly logic. Move multiplier name construction in MeanValueConstraint to after equation generation to avoid stale/dev-ordering issues. Expand LagrangeMultiplierAssembly docstring and add a unit test to verify nonzero mean-value constraint sign/behavior.