### PR TITLE
Simcoon 2.0 support; Verlet end-step accel & tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ semantic versioning.
 
 ### Changed
 
-- **fedoo now requires `simcoon >= 2.0`** (previously `>= 1.14`).
+- **fedoo now requires `simcoon >= 2.0.0b1`** (previously `>= 1.14`). fedoo 1.0
+  targets the simcoon 2.0 series, whose first release is the `2.0.0b1` beta.
 
 ### Migration — simcoon 2.0 `tangent_mode`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ semantic versioning.
 
 ### Changed
 
+- **`NonLinear.add_line_search` gained a `mode` argument** with three policies:
+  `"natural"` (new default), `"minimize"` (the previous residual-descent
+  behavior, with `method`) and `"safeguard"` (kinematic validity filter only,
+  `det F > 0`). The default `"natural"` mode accepts a trial step when
+  EITHER the classical Armijo test on `‖R‖` passes OR Deuflhard's
+  affine-invariant test on the *simplified Newton correction*
+  `K⁻¹ R(u + α dX)` does (one back-substitution per trial, the factorization
+  of the current tangent being reused; accepted when this correction is
+  smaller than the current one). The second merit, measured in displacement
+  space, is invariant to the scaling of the equations and does not strangle
+  the large legitimate steps of soft modes under force control (which
+  inflate `‖R‖` without being bad steps); the first one remains the proven
+  throttle against penalty-contact or plastic overshoot. `ls_mode` can also
+  be set through `set_nr_criterion`.
+  Factorization reuse (`set_reuse_factorization`) is enabled automatically
+  for the default direct solver.
+- A cached factorization (`set_reuse_factorization`) is now invalidated
+  automatically when the constraint reduction matrix changes
+  (`apply_boundary_conditions`), not only on `set_A`.
+
+### Fixed
+
+- `NonLinear`: the `elastic_initial_guess` / `force_elastic_matrix_next_iter`
+  options re-assembled the elastic matrix but never handed it to the elastic
+  prediction (a no-op beyond the first increment); they now refresh the
+  tangent.
+- `NonLinear.add_line_search` documents a contract that was only implicit: a
+  custom step-size callback must return exactly 1 while a Dirichlet increment
+  is pending. Returning `alpha < 1` defers the remaining `1 - alpha` of the
+  prescribed displacement, and convergence is only declared once nothing is
+  left to apply, so a callback that never returns 1 strands the increment and
+  the time step collapses to `dt_min`.
+- `NonLinear` with a `fd.time` integrator: the elastic prediction reused the
+  tangent of the previous increment even after the time step changed. A
+  transient tangent carries the `1/(beta dt^2)` inertia term, so that matrix
+  is wrong by `(dt_prev/dt)^2` -- a factor 16 after the standard x0.25 cut,
+  i.e. exactly when the solver is already struggling. The tangent is now
+  refreshed when `dt` changed (`set_start`/`to_start` have just re-assembled
+  it at the new step, so this only installs that matrix). Measured on a
+  plastic dynamic bending case with repeated cuts: 12 increments completed
+  instead of 5. Static problems and the legacy `ImplicitDynamic` weak form
+  are unaffected.
+- `NonLinear` with `adaptive_stiffness`: the iterate kept for the "redo the
+  last iteration" rollback was saved once the error had already risen, so the
+  rollback restored the bad iterate it was meant to undo. The last iterate
+  that actually improved the error is now kept instead. Measured on
+  `tube_compression`: 773 Newton iterations instead of 860 (and 779 instead
+  of 815 with the residual-descent line search).
+- `NonLinear` with `adaptive_stiffness`: the "safe" elastic matrix `KE` was
+  read from the reference assembly, i.e. under `nlgeom="UL"` the matrix of
+  the undeformed configuration (and, for an assembly sum, without the contact
+  block) for the whole run. When the divergence guard restarted an increment
+  with `set_A(KE)`, that matrix stayed installed across the time-step cuts:
+  every retry then failed at its first iteration with an infinite error, down
+  to `dt_min`. This made the `tube_compression` example abort at the contact
+  folds (reproducibly single-threaded, run-dependent otherwise). `KE` is now
+  read from the current assembly.
 - **fedoo now requires `simcoon >= 2.0.0b1`** (previously `>= 1.14`). fedoo 1.0
   targets the simcoon 2.0 series, whose first release is the `2.0.0b1` beta.
 

--- a/FORCE_CONTROL_RIGID_TIE.md
+++ b/FORCE_CONTROL_RIGID_TIE.md
@@ -1,0 +1,118 @@
+# Mission: force-controlled loading on free RigidTie DOFs
+
+> **RESOLVED 2026-09-03.** Root cause: the benchmark scripts used Newmark
+> (beta=0.25, gamma=0.6), which is only CONDITIONALLY stable (unconditional
+> requires beta >= (gamma+1/2)^2/4 = 0.3025): geometric high-frequency
+> growth killed every run after ~20-26 committed increments REGARDLESS of
+> dt, ramp speed or load (the increment-count signature was the give-away).
+> With beta=0.3025 the 20 N run completes: 200/200 increments,
+> ux = 44.70 mm (0.894 L, vs 45.5 mm displacement-control cross-check,
+> 1.8% = numerical damping), mean NR 1.95. A stability warning was added to
+> ImplicitDynamic.__init__. The robustness chain built along the way
+> (det F guard -> recoverable error, validity-only line search, LS on the
+> elastic prediction, convergence-gate fix) turned crashes into clean
+> failures and made the diagnosis possible -- keep it. Remaining side
+> findings: RigidTie tangent EXONERATED by control-swap FD (missing block
+> 4.4e-4 << k_rot); fd.time integrator + RigidBodyAssembly misbehaves on
+> retries (erratic from increment 4) -- separate issue; cap inertia
+> (PR#40) still structurally desirable.
+
+> **For the agent working on this**: read entirely; §2 is the evidence — do
+> not re-derive it. House rules: NEVER commit/push; leave user WIP alone.
+> Env: `source ~/miniconda3/etc/profile.d/conda.sh && conda activate 3mah &&
+> export KMP_DUPLICATE_LIB_OK=TRUE`. simcoon is the LOCAL git
+> (~/Documents/GitHub/simcoon, nothing pushed); rebuild with
+> `pip install --no-build-isolation .`.
+
+Date: 2026-09-02. Context: the NEOHC cantilever benchmark (ArtiSynth
+comparison). Displacement control (Dirichlet on RigidDispX) is fully healthy:
+static reaches 1.0 L, curve saved. FORCE control (Neumann 20 N on
+RigidDispX, all cap DOFs free) fails — this file scopes that.
+
+## 1. Symptom
+
+`Neumann("RigidDispX", 20 N)` on the RigidTie cap (implicit dynamics,
+gamma=0.6, rayleigh [50,0], dt fixed 0.01, quadratic ramp) dies between
+t ~ 0.15 and 0.21 (F ~ 0.5-0.9 N only!, cap rotY ~ 25-30 deg) with
+`MUMPSError: Matrix is numerically singular` — at a WANDERING increment
+(non-deterministic run to run).
+
+## 2. Evidence (measured; do not redo)
+
+- Displacement control, same everything: works to 1.0 L (static AND dynamic).
+- All 6 cap DOFs blocked by Dirichlet: OK. ANY free cap DOF + the 20 N
+  Neumann: fails. Tiny load (0.01 N, 2 increments): OK — so no structural
+  zero mode at start.
+- `pb.set_solver("direct_scipy")` (deterministic) survives further and
+  exposes the true failure: **simcoon `RU_decomposition` aborts**
+  (`sqrtmat_sympd(): given matrix is not symmetric / transformation failed`)
+  = a Newton ITERATE produced garbage/inverted F (det F <= 0) at Gauss
+  points. The MUMPS -10s are the same garbage states seen through the
+  threaded factorization (hence the non-determinism).
+- `pb.add_line_search(method="Quadratic")` + fixed dt: no more crashes
+  (clean "NR has not converged" instead) — overshoot confirmed as the
+  driver — but NR then stalls > 20 subiters at some increment.
+- line search + update_dt=True + dt_max=0.01: MUMPS -10 came back (a retry
+  path still assembles at a garbage state — the safeguard has holes).
+
+Interpretation: the free cap DOFs are ultra soft (bending stiffness of a
+soft slender rod: dF/du ~ 40 N/m at the origin; rotational ~ 2.5e-2 N.m/rad)
+and carry NO inertia (RigidTie global DOFs are massless — known PR#40 gap),
+so nothing bounds the first Newton iterate of an increment: it overshoots
+into element inversion. ArtiSynth's mirror works in force control because
+the cap is a true rigid body with mass + damping. A SECOND, unconfirmed
+contributor: the RigidTie MPC linearization omits the constraint's
+second-order term (tie forces x constraint curvature), which only enters
+the free-free block when a tie DOF is loaded — possibly the reason line
+search alone still stalls (> 20 iters).
+
+## 3. The work
+
+3.1 **fedoo NR safeguard (core, highest value)**: an NR iterate (or trial
+    state in line search / after dt reduction) whose kinematics update
+    yields det F <= 0 (or RU_decomposition failure) must be treated as a
+    FAILED step: backtrack alpha (line search) or reduce dt — never
+    assemble/factor at that state. Hook: the corate strain computation in
+    `stress_equilibrium.py` (update_1 path) can check det F cheaply and
+    raise a dedicated recoverable exception the NR loop catches like a
+    convergence failure. Cover the retry paths (the dt_max experiment shows
+    one is unguarded).
+
+3.2 **simcoon robustness**: exceptions thrown inside the parallel umat loop
+    (`simcoon_parallel_for` / GCD `dispatch_apply` in the python wrapper,
+    and RU_decomposition callers) currently escape a worker thread ->
+    `std::terminate` (libc++abi), killing Python. Capture per-worker (e.g.
+    std::exception_ptr per point, rethrow after the region) so fedoo can
+    catch and recover. This also matters beyond force control (any element
+    inversion today kills the interpreter).
+
+3.3 **RigidTie tangent completeness (verify, then fix or exonerate)**:
+    FD-check the assembled tangent (pattern of
+    tests/test_finite_strain_tangent_consistency.py) on a rotated,
+    force-loaded free-tie-DOF state — reachable safely via displacement
+    control to 0.4 L then RELEASING RigidDispX with the equilibrium force
+    applied as Neumann (state unchanged, control swapped). If FD shows an
+    O(F) inconsistency on the tie block, implement the constraint
+    second-order term in `constraint/rigid_tie.py`; if FD-exact, exonerate
+    and close.
+
+3.4 Optional API gap (ties into PR#40 items): inertia/damping on RigidTie
+    global DOFs (a cap with mass), which would make force-controlled
+    dynamics as robust as ArtiSynth's.
+
+## 4. Validation
+
+- The §1 run (quadratic ramp, dt=0.01 fixed, 200 increments) completes and
+  settles at ux ~ 45.5 mm = 0.911 L (cross-check from the
+  displacement-control curve: ~/scratch/artisynth/fedoo_comparison/
+  cantilever_curve_lin_0.050.csv), rotY ~ 60-70 deg at that point.
+- No process-killing exception under any failure mode (kill 3.2).
+- Full suite: `python -m pytest tests/ -q` -> 263 passed, 1 skipped today;
+  nothing may regress. Add a regression test for 3.1 (a load step engineered
+  to invert elements must retry, not crash).
+
+## 5. Meanwhile (user-facing workaround)
+
+The ArtiSynth comparison does NOT need fedoo force control: use
+displacement control on the fedoo side (full curve, includes the F=20 N
+point at 45.5 mm) and either protocol on the ArtiSynth side.

--- a/PR_FINITE_STRAIN_ROBUSTNESS.md
+++ b/PR_FINITE_STRAIN_ROBUSTNESS.md
@@ -1,0 +1,146 @@
+# Finite-strain consistency & nonlinear-solver robustness
+
+Synthesis of the working-tree changes for the fedoo PR (built on top of
+`fix/dynamics`). Companion of the simcoon PRs #101/#102 (exact spectral
+tangent transport): **requires simcoon master ≥ the #102 merge** — the new
+tests are gated by runtime capability probes and skip cleanly on older
+simcoon builds.
+
+## TL;DR
+
+Three long-standing root causes were identified by finite-difference
+verification of the assembled tangents and fixed; a robustness chain was
+added so that a diverging Newton iterate can never crash the process again.
+Benchmarks that were previously impossible now run:
+
+| Benchmark (NEOHC cantilever, nu = 0.49) | before | after |
+|---|---|---|
+| Displacement control, static, UL | stalls at 0.82 L (dt collapse) | **1.0 L**, 40 inc, NR mean 3.6 |
+| Force control 20 N, implicit dynamics | crash (`MUMPS -10` / `std::terminate`) at F ≈ 0.8 N | **45.6 mm = 0.912 L**, NR mean ≤ 2 |
+| Force control, `fd.time` integrator + massive cap (`RigidBodyAssembly`) | erratic divergence at increment 4 | **45.6 mm**, full ramp |
+| Test suite | 252 | **270 passed** (18 new tests) |
+
+## Root causes fixed
+
+### 1. 3D geometric stiffness was silently 2D-truncated
+`_init_nl_strain_op_vir` compared `space.ndim` (an int) to the string
+`"3D"` — always false — so every 3D finite-strain problem assembled the 2D
+initial-stress operator: all terms involving a Z derivative (S33/S13/S23
+slots and the k = Z rows) were missing. The tangent error was O(sigma),
+grew with load, and destroyed Newton on soft bending modes.
+*(converged solutions were never wrong — the residual was exact; only the
+tangent, i.e. convergence, was affected. Same remark for #2 and #3.)*
+
+### 2. UL tangent transport was not the Lie (Truesdell) tangent
+The UL log-corate branch used the umat box tangent (÷J) directly, while the
+tangent consistent with the Cauchy residual + standard initial-stress term
+is the Lie one. `update_2` now converts `box → dS/dE → DSDE_2_Dsigma_LieDD`
+for every simcoon law in UL (per-corate first-stage keys; native fedoo laws
+keep their engineering tangent — gated by the new
+`_corotational_box_tangent` attribute). `assume_sym` is now decided at
+initialize: `True` except UL, where the Lie tangent is not major-symmetric
+(a user-forced `True` warns and symmetrizes). Default corate is `log_r`
+(exact polar frame increment — the corate whose transport is exact in
+simcoon, including with rotated internal-variable history).
+
+### 3. Conditionally-stable Newmark pairs failed undiagnosed
+`(beta = 0.25, gamma = 0.6)` violates the A-stability condition
+`beta ≥ gamma/2`: high-frequency modes grow geometrically and the solve
+collapses after a few tens of increments **regardless of dt or load** — a
+failure that masquerades as Newton divergence / element inversion.
+`ImplicitDynamic` and `fd.time.GeneralizedAlpha` (hence `Newmark`) now warn
+on any conditionally stable set (`alpha_m ≤ alpha_f ≤ 1/2`,
+`gamma ≥ 1/2 − alpha_m + alpha_f`, `beta ≥ gamma/2`).
+
+## Robustness chain (new)
+
+- **`InvalidKinematicStateError`** (`core/base.py`): a trial state with
+  `det F ≤ 0` at any Gauss point is rejected at the kinematics stage
+  (`_comp_F` / `_comp_Fbar`) and treated by the NR loop as a failed
+  increment (dt cut + state restore) — never assembled. Previously it
+  produced NaN-filled matrices (reported as a spurious, non-deterministic
+  `MUMPS -10`) or killed the interpreter through simcoon's polar
+  decomposition.
+- **Line search redesigned as a validity filter** (`problem/line_search.py`):
+  the legitimate full Newton step of a soft mode can be large, and its
+  quadratic remainder — amplified by the stiff nodal equations — grows the
+  residual norm as step² (×10–×1000) while remaining an excellent step.
+  Any residual-monotone rule then strangles Newton (measured: alpha
+  collapsing to 3e-4, linear convergence, dt collapse). Default policy
+  (`ls_mode="safeguard"`): accept alpha = 1 whenever the trial state is
+  valid; geometric backtracking (×0.5, 0.8 safety) only on `det F ≤ 0`.
+  The residual-descent methods remain available via `ls_mode="minimize"`.
+  The line search is now also active on the elastic prediction under pure
+  force control (gate on the actual `_Xbc` content instead of the
+  `_boundary_is_0` proxy), and convergence acceptance no longer depends on
+  the alpha-driven flag (`_xbc_is_applied`).
+- **Duplicate-BC guard** (`core/boundary_conditions.py`): adding the same
+  BC *object* twice (e.g. a `RigidTie` explicitly added by the user and
+  auto-registered by `RigidBodyAssembly`) is now ignored. Duplicated MPCs
+  silently corrupted the elimination (MatCB) and destroyed Newton — the
+  cause of the `fd.time` + `RigidBodyAssembly` force-control failure.
+
+## Changes by file
+
+| File | Change |
+|---|---|
+| `fedoo/weakform/stress_equilibrium.py` | ndim fix (root cause 1); UL Lie conversion + per-corate first-stage keys; `corate="log_r"` default; assume_sym at initialize gated on `_corotational_box_tangent` (native UL laws keep the symmetric path); det F guard in `_comp_F`/`_comp_Fbar` incl. the element-center Jacobian (cofactor det, returned as J); tangent conversion skipped on line-search trials (`_line_search_update`, beam/plate pattern) |
+| `fedoo/weakform/stress_equilibrium_mixed.py` | det F guard in the mixed `_comp_F` too (before `log(J)` turns an inverted state into silent NaN) |
+| `fedoo/core/mechanical3d.py` | `_corotational_box_tangent = False` class default (native laws) |
+| `fedoo/constitutivelaw/simcoon_umat.py` | `_corotational_box_tangent = True` (simcoon umats) |
+| `fedoo/core/base.py` | `InvalidKinematicStateError` |
+| `fedoo/problem/non_linear.py` | catch invalid iterates in the NR loop; `_xbc_is_applied` convergence gate; `add_line_search(mode=...)` API + `ls_mode`/`ls_method`/`ls_max_iter` accepted by `set_nr_criterion` |
+| `fedoo/problem/line_search.py` | safeguard-first validity-filter line search; invalid trial → inf (sentinel never reaches the acceptance tests); minimize fallback bounded by the last valid alpha; `_xbc_is_applied` gate |
+| `fedoo/weakform/implicit_dynamic.py` | Newmark stability warning (shared helper), on `ImplicitDynamic2` too |
+| `fedoo/time/base.py` | `warn_if_conditionally_stable` — single stability guard used by `ImplicitDynamic` and `GeneralizedAlpha`/`Newmark` |
+| `fedoo/time/generalized_alpha.py` | generalized-alpha stability warning (shared helper) |
+| `fedoo/core/boundary_conditions.py` | identity guard in `ListBC.append` (the single insertion point; `extend` filters through it, `add` inherits it) |
+| `tests/test_weakform_factory_types.py` | updated to the assume_sym-at-initialize contract |
+| `examples/03-advanced/neohookean_cantilever_force.py` | NEW: force-driven companion example (massive rigid cap + `fd.time` Newmark) — exercises every fix of this PR; validated: 45.60 mm vs 45.5 expected |
+
+## New tests (18)
+
+- `tests/test_finite_strain_tangent_consistency.py` — FD consistency of the
+  assembled global tangent: NEOHC/ELISO/EPICP × TL/UL × corate log/log_R
+  (~1e-9 each), plus a committed-plastic-history case. Gated by runtime
+  capability probes on the installed simcoon (skip, never fail, on older
+  builds; TODO markers to replace the probes by a version pin once the
+  simcoon release number is fixed).
+- `tests/test_time_integrator_stability_warning.py` — the stability guards
+  warn on every violating (beta, gamma, alpha) set and stay silent on valid
+  ones.
+- `tests/test_bc_duplicate_registration.py` — a `RigidTie` ends up exactly
+  once in `pb.bc` in both registration orders.
+
+## Behavior notes for reviewers
+
+- Converged solutions are unchanged by 1–2 (tangent-only fixes); Newton
+  behavior improves everywhere (e.g. EPICP UL shear benchmark: 185 → 81
+  total NR iterations, flat 4/increment through gamma = 0.4).
+- `corate` default moved `"log"` → `"log_r"`. Both compute the exact log
+  strain; `log_r` uses the exact polar frame increment, for which the
+  simcoon tangent transport is exact including rotated plastic history
+  (with `"log"`/XBM a small, documented O(||EP||·dtheta) tangent residual
+  remains — harmless in practice).
+- `assume_sym` is now `False` in UL (unsymmetric solver path — slight cost,
+  required for correctness of the Lie tangent). Non-UL problems keep
+  `True`.
+- The line-search default changed for `add_line_search` users (opt-in
+  feature): safeguard mode. `add_line_search(mode="minimize")` restores the
+  previous residual-descent behavior.
+- Known cost (documented TODO in `line_search.py`): in safeguard mode the
+  validity test is a full residual evaluation whose work is redone by the
+  caller when the step is valid (~one vector assembly + umat sweep per NR
+  iteration when the line search is active). A kinematics-only validity
+  probe would remove it — deferred (touches the update machinery).
+- Known limits, out of scope, documented: pure-static force control on
+  quasi-rigid modes still requires continuation (Riks) or Tikhonov
+  stabilization (not implemented); hypoelastic multi-increment transport is
+  exact for `log_r` only.
+
+## Do not commit
+
+The root-level mission notes (`FORCE_CONTROL_RIGID_TIE.md`,
+`FEDOO_EXACT_TANGENT_FOLLOWUP.md`, this file if desired), `MaillageCylindre/`
+(~500 MB of meshes) and `fedoo.egg-info/` are untracked on purpose — do not
+`git add -A`.

--- a/conda.recipe/conda_build_config.yaml
+++ b/conda.recipe/conda_build_config.yaml
@@ -1,3 +1,0 @@
-solver_backend:
-   - pypardiso #[x86]
-   - petsc4py #[not x86]

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,7 +23,10 @@ requirements:
     - h5py
     - pyvista>=0.42
     - simcoon>=2.0.0b1
-    - {{ solver_backend }}
+    # python-mumps works on every platform (unlike pypardiso, Intel-only),
+    # which keeps the package noarch. The runtime solver selection prefers
+    # pypardiso when the user installs it on top (Intel machines).
+    - python-mumps
 
 test:
   imports:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -23,7 +23,8 @@ In addition, the conda package also includes some recommended dependencies:
 
     * `Simcoon <https://simcoon.readthedocs.io/en/latest/>`_
       brings a lot of features (finite strain, non-linear constitutive
-      laws, ...). Simcoon can be installed using conda or pip.
+      laws, ...). fedoo requires ``simcoon >= 2.0.0b1``. Simcoon can be
+      installed using conda or pip.
 
     * `PyVista <https://docs.pyvista.org/version/stable/>`_
       for results visualization and mesh utils.

--- a/examples/03-advanced/neohookean_cantilever_force.py
+++ b/examples/03-advanced/neohookean_cantilever_force.py
@@ -28,9 +28,11 @@ stabilization, are not used in this example). The robust protocol is
   (fedoo now warns in that case);
 * a slow force ramp (quadratic, gentle start) followed by a hold period so
   the response settles to the static equilibrium;
-* the (default) safeguard line search, which rejects only trial states
-  with inverted elements and never throttles legitimate large soft-mode
-  steps.
+* the safeguard line search (``mode="safeguard"``), which rejects only
+  trial states with inverted elements and never throttles legitimate large
+  soft-mode steps. The default ``mode="natural"`` (affine-invariant test on
+  the simplified Newton correction) handles them as well; a pure
+  residual-descent line search (``mode="minimize"``) would strangle them.
 
 Cross-check: the displacement-driven curve gives ``ux(F = 20 N) = 45.5 mm
 = 0.911 L``; this run settles within ~2% of it (the difference is the
@@ -101,7 +103,7 @@ assembly = assembly_fe + cap
 pb = fd.problem.NonLinear(assembly)
 pb.set_time_integrator(fd.time.SECOND_ORDER, fd.time.Newmark(beta=0.3025, gamma=0.6))
 pb.set_nr_criterion("Displacement", err0=1.0, tol=1e-3, max_subiter=20)
-pb.add_line_search()  # default mode: validity safeguard
+pb.add_line_search(mode="safeguard")  # validity filter, never throttles
 
 results = pb.add_output(
     "neohookean_cantilever_force", assembly_fe, ["Disp", "Stress", "Strain"]

--- a/examples/03-advanced/neohookean_cantilever_force.py
+++ b/examples/03-advanced/neohookean_cantilever_force.py
@@ -1,0 +1,162 @@
+"""
+Force-driven Neo-Hookean cantilever (massive rigid cap, implicit dynamics)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Companion of :ref:`the displacement-driven cantilever example
+<neohookean_cantilever>`: the same slender, nearly-incompressible NEOHC
+cylinder, but loaded by a **transverse force** applied to its rigid cap —
+the natural protocol when mirroring a dynamics engine such as ArtiSynth.
+
+Static force control is ill-posed here: the transverse stiffness of the
+cap is tiny (~40 N/m at the origin, rotational ~2.5e-2 N.m/rad), so a
+Newton step towards the distant equilibrium leaves any convergence basin
+(the classical remedies, arc-length continuation or Tikhonov
+stabilization, are not used in this example). The robust protocol is
+**quasi-static-by-dynamics**:
+
+* the cap is a true rigid body — a :class:`fedoo.constraint.RigidTie` for
+  the kinematics plus a :class:`~fedoo.constraint.rigid_body.RigidBodyAssembly`
+  carrying its 6x6 mass/inertia, so the Newmark term ``M/(beta*dt^2)``
+  regularizes the soft cap DOFs (this is exactly what makes the ArtiSynth
+  mirror robust);
+* a Newmark integrator attached at the problem level
+  (``pb.set_time_integrator``) with an **unconditionally stable** pair:
+  ``gamma = 0.6`` for high-frequency damping requires
+  ``beta >= gamma/2 = 0.30`` — a violating pair (e.g. the
+  default-looking ``beta = 0.25``) grows the high-frequency modes
+  geometrically and collapses after a few tens of increments, whatever dt
+  (fedoo now warns in that case);
+* a slow force ramp (quadratic, gentle start) followed by a hold period so
+  the response settles to the static equilibrium;
+* the (default) safeguard line search, which rejects only trial states
+  with inverted elements and never throttles legitimate large soft-mode
+  steps.
+
+Cross-check: the displacement-driven curve gives ``ux(F = 20 N) = 45.5 mm
+= 0.911 L``; this run settles within ~2% of it (the difference is the
+residual numerical damping at the end of the hold).
+
+The tie is registered automatically when the ``RigidBodyAssembly`` is part
+of the problem assembly — do not add it again (fedoo now ignores the
+duplicate, which used to corrupt the MPC elimination).
+"""
+
+import numpy as np
+
+import fedoo as fd
+from fedoo.constraint.rigid_body import RigidBodyAssembly
+
+# --------------------------------------------------------------------------
+# Parameters
+# --------------------------------------------------------------------------
+L, R = 0.05, 0.0025  # cylinder length / radius [m]
+E, nu = 60e6, 0.49  # Young's modulus [Pa], Poisson's ratio
+mu = E / (2 * (1 + nu))
+kappa = E / (3 * (1 - 2 * nu))
+rho = 1000.0  # cylinder density [kg/m^3]
+
+F_CAP = 20.0  # transverse force on the cap [N]
+RAMP = 1.0  # force ramp duration [s] (quadratic)
+HOLD = 1.0  # settling period at constant force [s]
+DT = 0.01  # time step [s] (kept constant: dt_max=DT)
+
+# a small physical cap: ~10 g, I ~ 1e-6 kg.m^2 — enough for the Newmark
+# inertia to regularize the soft cap DOFs at this time step
+M_CAP = 0.01
+I_CAP = 1e-6 * np.eye(3)
+
+# same Abaqus deck as the displacement-driven example (and as the
+# ArtiSynth mirror model)
+MESH_FILE = "../../util/meshes/cyl08_hexa_lin.inp"
+
+fd.ModelingSpace("3D")
+mesh = fd.Mesh.read(MESH_FILE)
+z = mesh.nodes[:, 2]
+bottom = mesh.find_nodes("Z", z.min())  # clamped base
+top = mesh.find_nodes("Z", z.max())  # tied to the rigid cap
+
+# --------------------------------------------------------------------------
+# Material, weak form, assemblies (FE + rigid cap inertia)
+# --------------------------------------------------------------------------
+material = fd.constitutivelaw.Simcoon("NEOHC", [mu, kappa], name="neohookean")
+material.set_density(rho)
+
+wf = fd.weakform.StressEquilibriumRI(material, nlgeom="UL")
+wf.list_weakform[0].geometric_stiffness = True
+assembly_fe = fd.Assembly.create(wf, mesh, name="cylinder")
+
+tie = fd.constraint.RigidTie(top)
+cap = RigidBodyAssembly(
+    mass=M_CAP,
+    inertia_tensor=I_CAP,
+    rigid_tie=tie,
+    mesh=mesh,
+    name="cap_inertia",
+)
+assembly = assembly_fe + cap
+
+# --------------------------------------------------------------------------
+# Problem: Newmark at the problem level, force ramp, safeguard line search
+# --------------------------------------------------------------------------
+pb = fd.problem.NonLinear(assembly)
+pb.set_time_integrator(fd.time.SECOND_ORDER, fd.time.Newmark(beta=0.3025, gamma=0.6))
+pb.set_nr_criterion("Displacement", err0=1.0, tol=1e-3, max_subiter=20)
+pb.add_line_search()  # default mode: validity safeguard
+
+results = pb.add_output(
+    "neohookean_cantilever_force", assembly_fe, ["Disp", "Stress", "Strain"]
+)
+
+# NB: the tie is auto-registered by the RigidBodyAssembly — no pb.bc.add(tie)
+pb.bc.add("Dirichlet", bottom, "Disp", 0)  # clamp the base
+TMAX = RAMP + HOLD
+pb.bc.add(
+    "Neumann",
+    "RigidDispX",
+    F_CAP,
+    # quadratic ramp on [0, RAMP], hold at F_CAP on [RAMP, TMAX]
+    time_func=lambda tf: min(tf * TMAX / RAMP, 1.0) ** 2,
+)
+
+history = []
+
+
+def record(problem):
+    ux = float(np.ravel(problem.get_dof_solution("RigidDispX"))[0])
+    history.append((problem.time, ux))
+
+
+pb.nlsolve(
+    dt=DT,
+    tmax=TMAX,
+    update_dt=True,
+    dt_max=DT,
+    print_info=1,
+    interval_output=0.05,
+    callback=record,
+)
+
+# --------------------------------------------------------------------------
+# Post-processing: settlement and cross-check
+# --------------------------------------------------------------------------
+hist = np.array(history)
+ux_final = hist[-1, 1]
+drift = abs(hist[-1, 1] - hist[-11, 1]) if len(hist) > 11 else float("nan")
+rot_y = float(np.ravel(pb.get_dof_solution("RigidRotY"))[0])
+
+print(
+    f"\nF = {F_CAP} N -> ux = {ux_final * 1000:.2f} mm ({ux_final / L:.3f} L), "
+    f"rotY = {np.degrees(rot_y):.1f} deg"
+)
+print(f"settlement drift over the last 10 steps: {drift * 1000:.4f} mm")
+print("displacement-control cross-check: 45.5 mm (0.911 L)")
+
+np.savetxt(
+    "neohookean_cantilever_force_history.csv",
+    hist,
+    delimiter=",",
+    header="time[s],ux_cap[m]",
+)
+
+results.load(results.n_iter - 1)
+results.plot("Stress", component="vm", data_type="Node", show=True)

--- a/examples/identification/README.rst
+++ b/examples/identification/README.rst
@@ -1,0 +1,7 @@
+Inverse identification
+----------------------
+
+Identification of material parameters from experimental data (load cell
+force, displacement of tracked points) with a fedoo finite-element forward
+model, the identification tools of simcoon (``Parameter``,
+``identification``) and the differential-evolution optimizer of scipy.

--- a/fedoo/constitutivelaw/simcoon_umat.py
+++ b/fedoo/constitutivelaw/simcoon_umat.py
@@ -38,11 +38,14 @@ class Simcoon(Mechanical3D):
       stiffness / hardening parameters with this convention or the
       response will not match the intended material orientation.
 
-    * Hyperelastic laws are gated on plane stress (see
-      ``_Lt_from_F`` branch); they remain compatible with 2Daxi at
+    * Hyperelastic laws (those with ``_Lt_from_F = True``) are gated on
+      plane stress; they remain compatible with 2Daxi at
       finite strain provided the F[θθ] = r/R fix is in effect (see
       :func:`fedoo.weakform.stress_equilibrium._comp_grad_disp`).
     """
+
+    _corotational_box_tangent = True
+    # simcoon umats return the corotational box tangent d(tau_hat)/dD
 
     def __init__(self, umat_name, props, name=""):
         # props is a nparray containing all the material variables

--- a/fedoo/core/base.py
+++ b/fedoo/core/base.py
@@ -691,6 +691,11 @@ class ProblemBase:
         """Return the current solver used for the problem."""
         return self.__solver[1]
 
+    @property
+    def _solver_type(self):
+        # name of the solver selected with set_solver ('direct', 'cg', ...)
+        return self.__solver[0]
+
 
 # Class to define global dof that are not associated with a mesh
 class _GlobalDof:

--- a/fedoo/core/base.py
+++ b/fedoo/core/base.py
@@ -11,6 +11,23 @@ import numpy as np
 import warnings
 from weakref import WeakSet
 
+
+class InvalidKinematicStateError(RuntimeError):
+    """A trial displacement state degenerates the kinematics.
+
+    Raised when a Newton iterate (or a line-search trial state) produces
+    det(F) <= 0 at some Gauss points: the constitutive evaluation is
+    meaningless there and assembling would fill the system with NaN.
+    RECOVERABLE in the NonLinear solver: its NR loop and line search treat
+    it as a failed iterate/increment (step backtracking or time-step
+    reduction). Other drivers (explicit dynamics, Linear solve_history)
+    have no rollback mechanism and let it propagate -- there it is a clear,
+    early abort instead of the silent NaN degradation it replaces.
+    """
+
+    pass
+
+
 # try to find the best available direct solver
 try:
     from pypardiso import spsolve

--- a/fedoo/core/boundary_conditions.py
+++ b/fedoo/core/boundary_conditions.py
@@ -135,6 +135,13 @@ class ListBC(BCBase):
     #     self.data.insert(index, bc)
 
     def append(self, bc):
+        if any(existing is bc for existing in self):
+            # Same OBJECT already registered: e.g. a RigidTie explicitly
+            # added by the user AND auto-registered by a RigidBodyAssembly
+            # (constraint/rigid_body.py _register_global_dofs). Adding it
+            # twice duplicates its MPCs, which silently corrupts the
+            # elimination (MatCB) and destroys Newton convergence.
+            return
         if self._problem is not None:
             bc.register_global_dofs(self._problem)
             bc.initialize(self._problem)
@@ -147,14 +154,21 @@ class ListBC(BCBase):
             self._update_during_inc = True
 
     def extend(self, iterable):
+        # keep only objects not already registered (identity guard: see append)
+        new_bcs = []
+        for bc in iterable:
+            if not any(existing is bc for existing in self) and not any(
+                existing is bc for existing in new_bcs
+            ):
+                new_bcs.append(bc)
         if self._problem is not None:
-            for bc in iterable:
+            for bc in new_bcs:
                 bc.register_global_dofs(self._problem)
                 bc.initialize(self._problem)
         if hasattr(iterable, "_keep_at_end") and iterable._keep_at_end:
-            self.data_end.extend(iterable)
+            self.data_end.extend(new_bcs)
         else:
-            self.data.extend(iterable)
+            self.data.extend(new_bcs)
 
         if hasattr(iterable, "_update_during_inc") and iterable._update_during_inc:
             self._update_during_inc = True
@@ -207,6 +221,9 @@ class ListBC(BCBase):
         """
         if len(args) == 1:  # assume arg[0] is a boundary condition object
             bc = args[0]
+            # NB: an object already registered (by identity) is silently
+            # ignored -- the guard lives in ListBC.append, the single
+            # insertion point.
             if hasattr(bc, "assemble_global_mat") and hasattr(bc, "current"):
                 # Assembly object
                 if hasattr(bc, "as_neumann"):

--- a/fedoo/core/dataset.py
+++ b/fedoo/core/dataset.py
@@ -25,9 +25,12 @@ except ImportError:
     USE_PYVISTA = False
 try:
     import pyvistaqt as pvqt
+    from qtpy import QtWidgets  # noqa: F401 - fails if no Qt binding is installed
 
     USE_PYVISTA_QT = True
-except ImportError:
+except (ImportError, RuntimeError):
+    # RuntimeError: qtpy raises QtBindingsNotFoundError (RuntimeError subclass
+    # in some versions) when pyvistaqt is installed without any Qt binding.
     USE_PYVISTA_QT = False
 
 try:

--- a/fedoo/core/dataset.py
+++ b/fedoo/core/dataset.py
@@ -35,6 +35,16 @@ except (ImportError, RuntimeError):
     USE_PYVISTA_QT = False
 
 
+def _has_interactor(plotter):
+    """True when the plotter owns a render window interactor.
+
+    A user-supplied pyvistaqt BackgroundPlotter under pyvista.OFF_SCREEN
+    has none: an interactive scalar bar must not be requested on it
+    (pyvista >= 0.48 fails instead of ignoring the request).
+    """
+    return getattr(plotter, "iren", None) is not None
+
+
 def _in_interactive_session():
     """True in a REPL/IPython session where a Qt event loop keeps running.
 
@@ -723,17 +733,18 @@ class DataSet:
 
         backgroundplotter = True
         owns_qt_plotter = False
-        if USE_PYVISTA_QT and (plotter is None or plotter == "qt"):
+        # off-screen rendering (screenshot, or pyvista.OFF_SCREEN as set by
+        # the gallery build) needs a plain plotter: the Qt BackgroundPlotter
+        # has no interactor there and would block on its event loop
+        off_screen = bool(screenshot or pv.OFF_SCREEN)
+        if USE_PYVISTA_QT and (plotter is None or plotter == "qt") and not off_screen:
             # use pyvistaqt plotter
             pl = pvqt.BackgroundPlotter(window_size=window_size)
             owns_qt_plotter = True
-        elif plotter is None or plotter == "pv":
+        elif plotter is None or plotter in ("pv", "qt"):
             # default pyvista plotter
             backgroundplotter = False
-            if screenshot:
-                pl = pv.Plotter(off_screen=True, window_size=window_size)
-            else:
-                pl = pv.Plotter(window_size=window_size)
+            pl = pv.Plotter(off_screen=off_screen, window_size=window_size)
         else:
             # try to use the given plotter
             # dont show
@@ -782,7 +793,7 @@ class DataSet:
             )
         else:
             sargs = dict(
-                interactive=True,
+                interactive=_has_interactor(pl),
                 title_font_size=20,
                 label_font_size=16,
                 color="Black",

--- a/fedoo/core/dataset.py
+++ b/fedoo/core/dataset.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 import os
+import sys
 from zipfile import ZipFile, Path as ZipPath
 from fedoo.core.mesh import Mesh, MultiMesh
 from fedoo.core.multimeshdata import MultiMeshData, copy_data_value
@@ -32,6 +33,20 @@ except (ImportError, RuntimeError):
     # RuntimeError: qtpy raises QtBindingsNotFoundError (RuntimeError subclass
     # in some versions) when pyvistaqt is installed without any Qt binding.
     USE_PYVISTA_QT = False
+
+
+def _in_interactive_session():
+    """True in a REPL/IPython session where a Qt event loop keeps running.
+
+    In a plain ``python script.py`` run there is no running event loop: a
+    ``BackgroundPlotter`` window would close as soon as the script ends, so
+    ``plot`` must block on the Qt event loop instead.
+    """
+    if hasattr(sys, "ps1"):
+        return True
+    ipython_mod = sys.modules.get("IPython")
+    return ipython_mod is not None and ipython_mod.get_ipython() is not None
+
 
 try:
     import pandas
@@ -707,9 +722,11 @@ class DataSet:
                 meshplot.cell_data[key] = np.asarray(value)
 
         backgroundplotter = True
+        owns_qt_plotter = False
         if USE_PYVISTA_QT and (plotter is None or plotter == "qt"):
             # use pyvistaqt plotter
             pl = pvqt.BackgroundPlotter(window_size=window_size)
+            owns_qt_plotter = True
         elif plotter is None or plotter == "pv":
             # default pyvista plotter
             backgroundplotter = False
@@ -944,6 +961,11 @@ class DataSet:
 
         if not (backgroundplotter) and show:
             return pl.show(return_cpos=return_cpos)
+
+        if owns_qt_plotter and show and not _in_interactive_session():
+            # Plain script run: block until the window is closed, otherwise
+            # the process exits and the window vanishes immediately.
+            pl.app.exec()
 
         return pl
 
@@ -1271,6 +1293,16 @@ class DataSet:
 
         if not backgroundplotter and show:
             return pl.show(return_cpos=return_cpos)
+
+        if (
+            USE_PYVISTA_QT
+            and (plotter is None or plotter == "qt")
+            and show
+            and not _in_interactive_session()
+        ):
+            # qt plotter created by the submesh plot calls above: same
+            # blocking behavior as in ``plot`` for plain script runs.
+            pl.app.exec()
 
         return pl
 

--- a/fedoo/core/mechanical3d.py
+++ b/fedoo/core/mechanical3d.py
@@ -105,6 +105,13 @@ class Mechanical3D(ConstitutiveLaw):
 
     # model of constitutive law for InternalForce Weakform
 
+    _corotational_box_tangent = False
+    # True when the law returns the simcoon corotational "box" tangent
+    # d(tau_hat)/dD, which the UL weakform must convert to the Lie
+    # (Truesdell) spatial tangent (see StressEquilibrium.update_2).
+    # Native fedoo laws (e.g. ElasticIsotrop) return a plain engineering
+    # tangent and are left unconverted.
+
     def __init__(self, name="", density=None):
         ConstitutiveLaw.__init__(self, name)
         self.density = density

--- a/fedoo/core/problem.py
+++ b/fedoo/core/problem.py
@@ -333,9 +333,18 @@ class Problem(ProblemBase):
             if self.__A.shape[0] != n_dof:  # probably not required
                 self.__A.resize((n_dof))
 
+            free_diagonal = self.__A[self._dof_free]
+            if np.any(free_diagonal == 0):
+                n_zero = int(np.count_nonzero(free_diagonal == 0))
+                raise ZeroDivisionError(
+                    f"{n_zero} free DOF(s) have a zero diagonal in the lumped "
+                    "mass matrix (e.g. a rotational/drilling DOF, or a node with "
+                    "no inertia contribution). Provide inertia for every active "
+                    "DOF, or constrain the massless DOFs, before solving."
+                )
             self.__X[self._dof_free] = (
                 self.__B[self._dof_free] + self.__D[self._dof_free]
-            ) / self.__A[self._dof_free]
+            ) / free_diagonal
 
     def get_X(self):  # solution of the linear system
         return self.__X

--- a/fedoo/core/problem.py
+++ b/fedoo/core/problem.py
@@ -6,6 +6,17 @@ from fedoo.core.base import ProblemBase, AssemblyBase
 from fedoo.core.output import _ProblemOutput, _get_results
 
 
+def _same_sparse(a, b):
+    """Cheap equality of two CSC matrices, short-circuiting on the metadata."""
+    return (
+        a.shape == b.shape
+        and a.nnz == b.nnz
+        and np.array_equal(a.indptr, b.indptr)
+        and np.array_equal(a.indices, b.indices)
+        and np.array_equal(a.data, b.data)
+    )
+
+
 class Problem(ProblemBase):
     """Base class to define a problem that generate a linear system and to solve
     the linear system with some defined boundary conditions.
@@ -263,6 +274,7 @@ class Problem(ProblemBase):
     def set_A(self, A):
         self.__A = A
         self.invalidate_factorization()
+        self._reduced_cache = None  # keyed on A: never outlive it
 
     def _set_A_from_assembly(self, A):
         """Internal: install the assembly's matrix without invalidating
@@ -277,9 +289,32 @@ class Problem(ProblemBase):
             return
         self.__A = A
         self.invalidate_factorization()
+        self._reduced_cache = None
 
     def get_A(self):
         return self.__A
+
+    def _reduced_system_matrix(self):
+        """Return MatCB.T A MatCB, the system matrix on the free dof.
+
+        Cached while A and MatCB are the same objects, so that with
+        factorization reuse (:meth:`set_reuse_factorization`) the elastic
+        prediction and the line-search trials skip the sparse triple product
+        as well as the factorization.
+        """
+        A, mat_cb = self.__A, self._MatCB
+        cache = getattr(self, "_reduced_cache", None)
+        if cache is None or cache[0] is not A or cache[1] is not mat_cb:
+            cache = (A, mat_cb, mat_cb.T @ A @ mat_cb)
+            self._reduced_cache = cache
+        return cache[2]
+
+    def _solve_reduced(self, rhs):
+        """Solve the free-dof system for a right-hand side (a
+        back-substitution when the factorization of the current matrix is
+        cached). Used by :meth:`solve` and by the line search for the
+        simplified Newton correction K^-1 R(u + alpha dX)."""
+        return self._solve(self._reduced_system_matrix(), rhs)
 
     def get_B(self):
         return self.__B
@@ -304,15 +339,10 @@ class Problem(ProblemBase):
 
             if len(self._dof_free) != 0:
                 if np.isscalar(self.__D) and self.__D == 0:
-                    self.__X[self._dof_free] = self._solve(
-                        self._MatCB.T @ self.__A @ self._MatCB,
-                        self._MatCB.T @ (self.__B - self.__A @ self._Xbc),
-                    )
+                    rhs = self._MatCB.T @ (self.__B - self.__A @ self._Xbc)
                 else:
-                    self.__X[self._dof_free] = self._solve(
-                        self._MatCB.T @ self.__A @ self._MatCB,
-                        self._MatCB.T @ (self.__B + self.__D - self.__A @ self._Xbc),
-                    )
+                    rhs = self._MatCB.T @ (self.__B + self.__D - self.__A @ self._Xbc)
+                self.__X[self._dof_free] = self._solve_reduced(rhs)
 
                 self.__X = self._MatCB * self.__X[self._dof_free] + self._Xbc
             else:
@@ -445,9 +475,14 @@ class Problem(ProblemBase):
             (data, np.ones(len(dof_free)))
         )  # data.append(np.ones(len(dof_free)))
 
-        self._MatCB = sparse.coo_matrix(
+        mat_cb = sparse.coo_matrix(
             (data, (row, col)), shape=(n_dof, len(dof_free))
         ).tocsc()  # so that self._MatCB.T is csr
+        if self._factor_valid and not _same_sparse(self._MatCB, mat_cb):
+            # a cached factorization (set_reuse_factorization) is that of
+            # MatCB.T A MatCB: stale if the constraint matrix changed
+            self.invalidate_factorization()
+        self._MatCB = mat_cb
 
         self.__B = F
         self._dof_slave = dof_slave

--- a/fedoo/problem/__init__.py
+++ b/fedoo/problem/__init__.py
@@ -402,8 +402,13 @@ direction requires a "safe" search direction.
 ~~~~~~~~~~~~~~~~~~~~~~
 For strong instabilities (such as buckling or snap-through) where the tangent 
 stiffness matrix becomes non-positive definite, the **Eigenvalue Shift** technique might
-be effective. Note that this method is computationally 
-expensive with limited results, and should only be used as a last resort.
+be effective. This feature is **experimental**: it is computationally expensive
+and, as measured, often has no effect at all. Two known limitations: the
+spectral estimate is computed on the *unreduced* matrix (it therefore sees the
+modes of the blocked and rigid-body degrees of freedom, not those of the system
+actually solved), and the shift is added before that reduction, which with
+multi-point constraints does not yield ``reduced + alpha*I``. Use it only as a
+last resort, after ``adaptive_stiffness`` and a dynamic solver.
 
 * **Mechanism**: Adds a scaled identity matrix :math:`\alpha \mathbf{I}` to the 
   tangent stiffness :math:`\mathbf{K_T}`.

--- a/fedoo/problem/explicit_dynamic.py
+++ b/fedoo/problem/explicit_dynamic.py
@@ -109,6 +109,10 @@ class ExplicitDynamic(Problem):
         self._evaluation = None
         self._force_is_assembled = False
         self._assembled_internal_force = None
+        self._assembled_force_displacement = None
+        self._assembled_force_complete = False
+        self._acceleration_initialized = False
+        self._initial_acceleration_user_supplied = False
         self._mass_assembly = None
         self._storage_data = None
         self._mass = None
@@ -127,19 +131,11 @@ class ExplicitDynamic(Problem):
             velocity=self._new_vect_dof(),
             acceleration=self._new_vect_dof(),
         )
-        self._state_start = self._copy_state(self._state)
+        self._state_start = self._state.copy()
         self._time_start = self.time
         self.set_X(self._state.displacement.copy())
         self.set_time_integrator(
             SECOND_ORDER, integrator if integrator is not None else CentralDifference()
-        )
-
-    @staticmethod
-    def _copy_state(state):
-        return ExplicitDynamicState(
-            state.displacement.copy(),
-            state.velocity.copy(),
-            state.acceleration.copy(),
         )
 
     def _global_matrix(self):
@@ -234,24 +230,23 @@ class ExplicitDynamic(Problem):
         return np.asarray(self._mass_matrix @ vector).ravel()
 
     def _end_step_acceleration(self, velocity):
-        """Return ``M^-1 f_int(u)`` at the current displacement on free DOFs.
+        """Return the complete acceleration at the current displacement.
 
         This closes the symplectic central-difference velocity update. The
-        acceleration is defined by the internal (and constant external) force
-        only; Rayleigh damping is applied explicitly in the drift, so it is
-        intentionally excluded here. Storage providers may however carry a
-        velocity-proportional term inside ``get_time_inertia_force`` (the same
-        bias subtracted by ``_update_d``): it is removed at ``velocity``, the
-        end-step velocity estimate used by the solve, so the balance
-        ``M a + f_v(v) = f`` holds for the reported acceleration. Blocked DOFs
-        are set by the driver from the prescribed motion.
+        force balance includes Neumann loads, internal force, Rayleigh damping
+        and velocity-proportional assembly-provider terms. ``velocity`` is an
+        explicit end-step predictor, so no nonlinear velocity iteration is
+        introduced. Blocked DOFs are set by the driver from prescribed motion.
         """
         if self._assembled_internal_force is not None:
-            internal_force = self._assembled_internal_force
+            force = self._assembled_internal_force.copy()
         else:
-            internal_force = self._linear_internal_force(self._state.displacement)
-        if self._assembly_storage_providers:
-            internal_force = internal_force - self._assembly_inertia_bias(velocity)
+            force = self._linear_internal_force(self._state.displacement)
+        external_force = self.get_B()
+        if not np.isscalar(external_force):
+            force = force + np.asarray(external_force).ravel()
+        force = force - self._assembly_inertia_bias(velocity)
+        force = force - self._damping_force(velocity)
         acceleration = self._new_vect_dof()
         free = self._dof_free
         if len(free) == 0:
@@ -261,14 +256,25 @@ class ExplicitDynamic(Problem):
             and not self._assembly_storage_providers
             and self._mass is not None
         ):
-            acceleration[free] = internal_force[free] / self._mass[free]
+            acceleration[free] = force[free] / self._mass[free]
         else:
             reduced_mass = self._MatCB.T @ self._mass_matrix @ self._MatCB
-            reduced_force = self._MatCB.T @ internal_force
+            reduced_force = self._MatCB.T @ force
             acceleration = np.asarray(
                 self._MatCB @ self._solve(reduced_mass, reduced_force)
             ).ravel()
         return acceleration
+
+    def _initialize_current_acceleration(self):
+        """Establish ``a_n = M^-1 f(u_n, v_n)`` before the first drift."""
+        if (
+            self._acceleration_initialized
+            or not self.time_integrator.needs_end_step_acceleration
+        ):
+            return
+        self._state.acceleration = self._end_step_acceleration(self._state.velocity)
+        self._acceleration_initialized = True
+        self._state_start = self._state.copy()
 
     def _default_mass_refresh(self):
         return any(
@@ -403,6 +409,8 @@ class ExplicitDynamic(Problem):
             + np.asarray(self._stiffness_matrix @ self._state.displacement).ravel()
         )
         self._assembled_internal_force = initial_force.copy()
+        self._assembled_force_displacement = self._state.displacement.copy()
+        self._assembled_force_complete = True
 
         self._storage_data = build_storage_assembly(self.__assembly, SECOND_ORDER)
         self._mass_assembly = self._storage_data.assembly
@@ -421,7 +429,7 @@ class ExplicitDynamic(Problem):
         self._update_a(update_mass=False)
         self.set_D(self._new_vect_dof())
         self._initialized = True
-        self._state_start = self._copy_state(self._state)
+        self._state_start = self._state.copy()
         self._time_start = self.time
 
     def evaluate(self, update_weakform=False, compute="all"):
@@ -442,20 +450,35 @@ class ExplicitDynamic(Problem):
         )
         self.set_X(self._evaluation[0].copy())
         if update_weakform:
-            self.__assembly.update(self, compute)
-            if compute != "vector":
-                self._stiffness_matrix = self._global_matrix()
-                self._refresh_rayleigh_damping_matrix()
-            if compute != "matrix":
-                force = self.__assembly.current.get_global_vector()
-                self._assembled_internal_force = (
-                    self._new_vect_dof()
-                    if np.isscalar(force)
-                    else np.asarray(force).ravel().copy()
+            reuse_complete_force = (
+                compute == "all"
+                and self._assembled_force_complete
+                and self._assembled_internal_force is not None
+                and self._assembled_force_displacement is not None
+                and np.array_equal(
+                    self._evaluation[0], self._assembled_force_displacement
                 )
+            )
+            if reuse_complete_force:
+                self._force_is_assembled = True
             else:
-                self._assembled_internal_force = None
-            self._force_is_assembled = compute != "matrix"
+                self.__assembly.update(self, compute)
+                if compute != "vector":
+                    self._stiffness_matrix = self._global_matrix()
+                    self._refresh_rayleigh_damping_matrix()
+                if compute != "matrix":
+                    force = self.__assembly.current.get_global_vector()
+                    self._assembled_internal_force = (
+                        self._new_vect_dof()
+                        if np.isscalar(force)
+                        else np.asarray(force).ravel().copy()
+                    )
+                    self._assembled_force_displacement = self._evaluation[0].copy()
+                else:
+                    self._assembled_internal_force = None
+                    self._assembled_force_displacement = None
+                self._assembled_force_complete = compute == "all"
+                self._force_is_assembled = compute != "matrix"
         else:
             evaluation_is_current = np.array_equal(
                 self._evaluation[0], self._state.displacement
@@ -472,6 +495,11 @@ class ExplicitDynamic(Problem):
         compute="all",
     ):
         """Prepare ``A`` and ``D`` for one subsequent call to ``solve()``."""
+        if not self._initialized:
+            self.initialize()
+        if np.isscalar(self._Xbc):
+            self.apply_boundary_conditions()
+        self._initialize_current_acceleration()
         self.evaluate(update_weakform=update_weakform, compute=compute)
         if update_mass is None:
             update_providers = self._default_mass_refresh()
@@ -497,10 +525,10 @@ class ExplicitDynamic(Problem):
             raise TypeError(
                 f"Unexpected ExplicitDynamic.solve keyword: {next(iter(kwargs))}"
             )
-        if not self._step_prepared:
-            self.prepare_time_increment(update_weakform=False)
         if np.isscalar(self._Xbc):
             self.apply_boundary_conditions()
+        if not self._step_prepared:
+            self.prepare_time_increment(update_weakform=False)
 
         operator = self.get_A()
         if getattr(operator, "ndim", 0) == 1:
@@ -527,7 +555,7 @@ class ExplicitDynamic(Problem):
         """
         if not self._step_solved:
             raise RuntimeError("solve() must be called before update().")
-        previous_state = self._copy_state(self._state)
+        previous_state = self._state.copy()
         self._state = self.time_integrator.state_from_displacement(
             self._state,
             self._predicted,
@@ -549,10 +577,15 @@ class ExplicitDynamic(Problem):
                     if np.isscalar(force)
                     else np.asarray(force).ravel().copy()
                 )
+                self._assembled_force_displacement = self._state.displacement.copy()
             else:
                 self._assembled_internal_force = None
+                self._assembled_force_displacement = None
+            self._assembled_force_complete = compute == "all"
         else:
             self._assembled_internal_force = None
+            self._assembled_force_displacement = None
+            self._assembled_force_complete = False
         if update_mass:
             self._assemble_fe_mass()
             self._mass_matrix = self._current_mass_matrix(refresh_providers=True)
@@ -563,19 +596,26 @@ class ExplicitDynamic(Problem):
             # end-step acceleration also becomes a_n for the next drift, keeping
             # the mass-history predictor consistent with the current geometry.
             dt = self.time_step
-            # Velocity estimate for velocity-proportional provider forces: the
-            # one the solve used (alpha/predictor evaluation), still available
-            # here since _evaluation is cleared below.
-            if self._evaluation is not None:
-                evaluation_velocity = self._evaluation[1]
-            else:
-                evaluation_velocity = previous_state.velocity
-            end_acceleration = self._end_step_acceleration(evaluation_velocity)
+            # Explicit full-step predictor used for damping and other
+            # velocity-dependent forces. It preserves one force evaluation per
+            # accepted nonlinear state and does not introduce an iteration.
+            predicted_end_velocity = previous_state.velocity + (
+                dt * previous_state.acceleration
+            )
+            end_acceleration = self._end_step_acceleration(predicted_end_velocity)
             velocity = previous_state.velocity + 0.5 * dt * (
                 previous_state.acceleration + end_acceleration
             )
-            blocked = getattr(self, "_dof_blocked", None)
-            if blocked is not None and len(blocked):
+            if self._MFext is None:
+                # Without MPCs, _dof_slave contains only Dirichlet DOFs and is
+                # already stored by the generic boundary-condition machinery.
+                blocked = self._dof_slave
+            else:
+                # With MPCs, distinguish directly prescribed DOFs from other
+                # eliminated slaves before enforcing their kinematics.
+                dirichlet = getattr(self, "_dof_blocked", set())
+                blocked = np.fromiter(dirichlet, dtype=int, count=len(dirichlet))
+            if len(blocked):
                 displacement = self._state.displacement
                 velocity[blocked] = (
                     displacement[blocked] - previous_state.displacement[blocked]
@@ -585,6 +625,7 @@ class ExplicitDynamic(Problem):
                 ) / dt
             self._state.velocity = velocity
             self._state.acceleration = end_acceleration
+            self._acceleration_initialized = True
 
         self._step_prepared = False
         self._step_solved = False
@@ -596,7 +637,17 @@ class ExplicitDynamic(Problem):
     def set_start(self, save_results=False, callback=None):
         """Commit assembly history and optionally save the accepted state."""
         self.__assembly.set_start(self)
-        self._state_start = self._copy_state(self._state)
+        self._stiffness_matrix = self._global_matrix()
+        force = self.__assembly.current.get_global_vector()
+        self._assembled_internal_force = (
+            self._new_vect_dof()
+            if np.isscalar(force)
+            else np.asarray(force).ravel().copy()
+        )
+        self._assembled_force_displacement = self._state.displacement.copy()
+        self._assembled_force_complete = True
+        self._refresh_rayleigh_damping_matrix()
+        self._state_start = self._state.copy()
         self._time_start = self.time
         if save_results:
             self.save_results(self._output_counter)
@@ -606,10 +657,13 @@ class ExplicitDynamic(Problem):
 
     def to_start(self):
         """Restore the last state committed by :meth:`set_start`."""
-        self._state = self._copy_state(self._state_start)
+        self._state = self._state_start.copy()
         self.time = self._time_start
         self.set_X(self._state.displacement.copy())
         self.__assembly.to_start(self)
+        self._assembled_internal_force = None
+        self._assembled_force_displacement = None
+        self._assembled_force_complete = False
         self._step_prepared = False
         self._step_solved = False
 
@@ -624,12 +678,12 @@ class ExplicitDynamic(Problem):
         t_fact=1.0,
     ):
         """Prepare, solve and update one complete explicit increment."""
+        if apply_boundary_conditions:
+            self.apply_boundary_conditions(t_fact=t_fact)
         self.prepare_time_increment(
             update_weakform=update_weakform,
             update_mass=update_mass,
         )
-        if apply_boundary_conditions:
-            self.apply_boundary_conditions(t_fact=t_fact)
         self.solve()
         self.update(update_weakform=update_weakform)
         if set_start:
@@ -651,6 +705,8 @@ class ExplicitDynamic(Problem):
             if np.isscalar(force)
             else np.asarray(force).ravel().copy()
         )
+        self._assembled_force_displacement = self._state.displacement.copy()
+        self._assembled_force_complete = False
 
     def solve_history(
         self,
@@ -806,12 +862,21 @@ class ExplicitDynamic(Problem):
     def set_initial_displacement(self, name, value):
         self._set_vect_component(self._state.displacement, name, value)
         self.set_X(self._state.displacement.copy())
+        self._assembled_internal_force = None
+        self._assembled_force_displacement = None
+        self._assembled_force_complete = False
+        if not self._initial_acceleration_user_supplied:
+            self._acceleration_initialized = False
 
     def set_initial_velocity(self, name, value):
         self._set_vect_component(self._state.velocity, name, value)
+        if not self._initial_acceleration_user_supplied:
+            self._acceleration_initialized = False
 
     def set_initial_acceleration(self, name, value):
         self._set_vect_component(self._state.acceleration, name, value)
+        self._initial_acceleration_user_supplied = True
+        self._acceleration_initialized = True
 
     def set_rayleigh_damping(self, alpha, beta):
         """Override weakform damping with ``C = alpha*M + beta*K``."""
@@ -835,8 +900,13 @@ class ExplicitDynamic(Problem):
             velocity=self._new_vect_dof(),
             acceleration=self._new_vect_dof(),
         )
-        self._state_start = self._copy_state(self._state)
+        self._state_start = self._state.copy()
         self._initialized = False
+        self._assembled_internal_force = None
+        self._assembled_force_displacement = None
+        self._assembled_force_complete = False
+        self._acceleration_initialized = False
+        self._initial_acceleration_user_supplied = False
         self._step_prepared = False
         self._step_solved = False
         self.time = 0.0

--- a/fedoo/problem/explicit_dynamic.py
+++ b/fedoo/problem/explicit_dynamic.py
@@ -233,6 +233,43 @@ class ExplicitDynamic(Problem):
     def _mass_action(self, vector):
         return np.asarray(self._mass_matrix @ vector).ravel()
 
+    def _end_step_acceleration(self, velocity):
+        """Return ``M^-1 f_int(u)`` at the current displacement on free DOFs.
+
+        This closes the symplectic central-difference velocity update. The
+        acceleration is defined by the internal (and constant external) force
+        only; Rayleigh damping is applied explicitly in the drift, so it is
+        intentionally excluded here. Storage providers may however carry a
+        velocity-proportional term inside ``get_time_inertia_force`` (the same
+        bias subtracted by ``_update_d``): it is removed at ``velocity``, the
+        end-step velocity estimate used by the solve, so the balance
+        ``M a + f_v(v) = f`` holds for the reported acceleration. Blocked DOFs
+        are set by the driver from the prescribed motion.
+        """
+        if self._assembled_internal_force is not None:
+            internal_force = self._assembled_internal_force
+        else:
+            internal_force = self._linear_internal_force(self._state.displacement)
+        if self._assembly_storage_providers:
+            internal_force = internal_force - self._assembly_inertia_bias(velocity)
+        acceleration = self._new_vect_dof()
+        free = self._dof_free
+        if len(free) == 0:
+            return acceleration
+        if (
+            self.mass_lumping
+            and not self._assembly_storage_providers
+            and self._mass is not None
+        ):
+            acceleration[free] = internal_force[free] / self._mass[free]
+        else:
+            reduced_mass = self._MatCB.T @ self._mass_matrix @ self._MatCB
+            reduced_force = self._MatCB.T @ internal_force
+            acceleration = np.asarray(
+                self._MatCB @ self._solve(reduced_mass, reduced_force)
+            ).ravel()
+        return acceleration
+
     def _default_mass_refresh(self):
         return any(
             not getattr(provider, "storage_matrix_is_constant", False)
@@ -490,6 +527,7 @@ class ExplicitDynamic(Problem):
         """
         if not self._step_solved:
             raise RuntimeError("solve() must be called before update().")
+        previous_state = self._copy_state(self._state)
         self._state = self.time_integrator.state_from_displacement(
             self._state,
             self._predicted,
@@ -518,6 +556,35 @@ class ExplicitDynamic(Problem):
         if update_mass:
             self._assemble_fe_mass()
             self._mass_matrix = self._current_mass_matrix(refresh_providers=True)
+
+        if self.time_integrator.needs_end_step_acceleration:
+            # Close velocity Verlet: v_{n+1} = v_n + 0.5*dt*(a_n + a_{n+1}) with
+            # a_{n+1} = M^-1 f(u_{n+1}) evaluated at the just-updated state. The
+            # end-step acceleration also becomes a_n for the next drift, keeping
+            # the mass-history predictor consistent with the current geometry.
+            dt = self.time_step
+            # Velocity estimate for velocity-proportional provider forces: the
+            # one the solve used (alpha/predictor evaluation), still available
+            # here since _evaluation is cleared below.
+            if self._evaluation is not None:
+                evaluation_velocity = self._evaluation[1]
+            else:
+                evaluation_velocity = previous_state.velocity
+            end_acceleration = self._end_step_acceleration(evaluation_velocity)
+            velocity = previous_state.velocity + 0.5 * dt * (
+                previous_state.acceleration + end_acceleration
+            )
+            blocked = getattr(self, "_dof_blocked", None)
+            if blocked is not None and len(blocked):
+                displacement = self._state.displacement
+                velocity[blocked] = (
+                    displacement[blocked] - previous_state.displacement[blocked]
+                ) / dt
+                end_acceleration[blocked] = (
+                    velocity[blocked] - previous_state.velocity[blocked]
+                ) / dt
+            self._state.velocity = velocity
+            self._state.acceleration = end_acceleration
 
         self._step_prepared = False
         self._step_solved = False

--- a/fedoo/problem/line_search.py
+++ b/fedoo/problem/line_search.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 
+from fedoo.core.base import InvalidKinematicStateError
+
 
 def _line_search_manager(pb, dX):
     """Combine several reistered line search algorithms.
@@ -28,40 +30,78 @@ def _evaluate_residual_norm(pb, dX, alpha):
     # 1. Temporarily update the displacement increment
     pb.assembly._save_sv()  # save assembly stat_variables
     pb._dU += alpha * dX
-
-    # 2. Re-assemble the internal force vector (D) at the new displacement
-    # Note: 'vector' compute usually updates internal forces/stresses
     pb._line_search_update = True
-    pb.update(compute="vector")
-    pb._update_d()
-    pb._line_search_update = False
+    try:
+        # 2. Re-assemble the internal force vector (D) at the new displacement
+        # Note: 'vector' compute usually updates internal forces/stresses
+        try:
+            pb.update(compute="vector")
+            pb._update_d()
+        except InvalidKinematicStateError:
+            # degenerated trial state (det F <= 0): infinitely bad candidate,
+            # backtracking will shrink alpha
+            return np.inf, None
 
-    # 3. Calculate residual R = B + D
-    # use MatBC to catch only the free_node values and eliminate mpc
-    # slave nodes
-    res = pb._get_free_dof_residual()
-
-    # 4. Cleanup: Restore original dU so we don't permanently alter state during search
-    pb._dU -= alpha * dX
-    pb.assembly._load_sv()
-
-    return np.linalg.norm(res, pb.nr_parameters["norm_type"]), res
+        # 3. Calculate residual R = B + D
+        # use MatBC to catch only the free_node values and eliminate mpc
+        # slave nodes
+        res = pb._get_free_dof_residual()
+        return np.linalg.norm(res, pb.nr_parameters["norm_type"]), res
+    finally:
+        # 4. Cleanup: restore the original state so the search never
+        # permanently alters it
+        pb._line_search_update = False
+        pb._dU -= alpha * dX
+        pb.assembly._load_sv()
 
 
 def line_search(pb, dX):
     """Line search to find an appropriate step size alpha.
-    Methods: Residual, Armijo, Energy, Quadratic.
 
-    To be assigned to self._step_size_callback.
+    To be assigned to self._step_size_callback. Two modes, selected by the
+    nr parameter "ls_mode" (see Problem.add_line_search):
+
+    - "safeguard" (default): pure validity filter (see below);
+    - "minimize": residual-descent methods (Residual, Armijo, Quadratic,
+      Energy), selected by the nr parameter "ls_method".
     """
-    if not (pb._boundary_is_0):
-        # avoid using line_search if dirichlet boundary conditions are not 0
-        # to avoid problems related to BC scaling.
+    if not pb._xbc_is_applied():
+        # avoid using line_search if dirichlet increment values are not 0
+        # to avoid problems related to BC scaling. NB: testing the actual
+        # _Xbc content (and not only the _boundary_is_0 flag) keeps the
+        # line search ACTIVE on the elastic prediction under pure force
+        # control -- the most dangerous iterate for soft free modes.
         return 1
 
-    # Configuration
-    method = pb.nr_parameters.get("ls_method", "Residual")
-    alpha = 1.0
+    # --- Safeguard-first acceptance of the full Newton step -----------------
+    # The legitimate full Newton step of a soft mode can be LARGE (e.g. a
+    # 13 deg cap rotation towards a distant equilibrium): its quadratic
+    # remainder, amplified by the stiff nodal equations, grows the residual
+    # norm as step^2 (x10-x1000) while remaining an excellent step that the
+    # next iteration kills quadratically. Any residual-monotone rule then
+    # strangles Newton. Default policy ("safeguard"): the line search is a
+    # PURE VALIDITY FILTER (IPC-style) -- backtrack only on a degenerated
+    # trial state (det F <= 0 -> norm inf), with a 0.8 safety factor, and
+    # let the main loop's divergence detector handle true divergence.
+    # TODO(perf): in safeguard mode this full residual evaluation only
+    # tests det F > 0 -- when valid (the common case) its work is redone
+    # by the caller. A kinematics-only validity probe would remove one
+    # vector assembly + umat sweep per NR iteration.
+    ls_mode = pb.nr_parameters.get("ls_mode", "safeguard")
+    norm_1, res_1 = _evaluate_residual_norm(pb, dX, 1.0)
+    # invalid full step: geometric backtracking to the first VALID alpha
+    alpha_valid = 1.0
+    while not np.isfinite(norm_1) and alpha_valid > 1e-4:
+        alpha_valid *= 0.5
+        norm_1, res_1 = _evaluate_residual_norm(pb, dX, alpha_valid)
+    if ls_mode == "safeguard":
+        if alpha_valid == 1.0:
+            return 1
+        return max(0.8 * alpha_valid, 1e-4)
+
+    # --- minimize mode: residual-descent methods ---
+    method = pb.nr_parameters.get("ls_method", "Quadratic")
+    alpha = alpha_valid
     rho = 0.5  # Standard backtracking contraction factor
     c1 = 1e-4  # Armijo sufficient decrease constant
     max_iter = pb.nr_parameters.get("ls_max_iter", 5)
@@ -77,13 +117,24 @@ def line_search(pb, dX):
         dX_free = dX[pb._dof_free] if hasattr(pb, "_dof_free") else dX
         work_0 = np.dot(res_0, dX_free)
 
-    # Tracking the best step in case we exhaust max_iter
-    best_alpha = 1.0
+    # Tracking the best step in case we exhaust max_iter. Start from the
+    # last VALID alpha, never 1.0: if every trial below is invalid the
+    # fallback must not return the full step the validity stage rejected.
+    best_alpha = alpha_valid
     best_norm = float("inf")
 
+    # the first trial (alpha = alpha_valid) reuses the evaluation of the
+    # validity stage above instead of re-assembling the same point
+    norm_alpha, res_alpha = norm_1, res_1
     for i in range(max_iter):
-        # Evaluate trial alpha
-        norm_alpha, res_alpha = _evaluate_residual_norm(pb, dX, alpha)
+        if i > 0:
+            # Evaluate trial alpha
+            norm_alpha, res_alpha = _evaluate_residual_norm(pb, dX, alpha)
+        if not np.isfinite(norm_alpha):
+            # invalid trial state (det F <= 0): shrink and retry -- the
+            # (inf, None) sentinel must not reach the acceptance tests
+            alpha *= rho
+            continue
         f_alpha = 0.5 * (norm_alpha**2)
 
         # Track the lowest residual seen so far

--- a/fedoo/problem/line_search.py
+++ b/fedoo/problem/line_search.py
@@ -4,6 +4,11 @@ import numpy as np
 
 from fedoo.core.base import InvalidKinematicStateError
 
+_ARMIJO_C1 = 1e-4  # Armijo sufficient-decrease constant (residual metric)
+_NATURAL_C = (
+    1e-3  # sufficient-decrease margin of the natural test (displacement metric)
+)
+
 
 def _line_search_manager(pb, dX):
     """Combine several reistered line search algorithms.
@@ -26,9 +31,14 @@ def _line_search_manager(pb, dX):
 
 
 def _evaluate_residual_norm(pb, dX, alpha):
-    """Calculate the norm of the residual at a trial step alpha."""
+    """Calculate the norm of the residual at a trial step alpha.
+
+    The problem is left exactly as found: the displacement increment, the
+    assembly state variables and the out-of-balance vector D are restored.
+    """
     # 1. Temporarily update the displacement increment
     pb.assembly._save_sv()  # save assembly stat_variables
+    d_0 = pb.get_D()
     pb._dU += alpha * dX
     pb._line_search_update = True
     try:
@@ -53,17 +63,50 @@ def _evaluate_residual_norm(pb, dX, alpha):
         pb._line_search_update = False
         pb._dU -= alpha * dX
         pb.assembly._load_sv()
+        pb.set_D(d_0)
+
+
+def _natural_test(pb, res, dx_norm, alpha, norm_type):
+    r"""Deuflhard's affine-invariant sufficient-decrease test.
+
+    The merit is the SIMPLIFIED Newton correction
+    :math:`\bar{dX}(\alpha) = K^{-1} R(u + \alpha\, dX)`, one
+    back-substitution on the cached factorization of the current tangent.
+    Unlike :math:`\|R\|` it lives in displacement space and is invariant to
+    the scaling of the equations (Deuflhard, *Newton Methods for Nonlinear
+    Problems*, NLEQ-ERR), so the stiff nodal equations no longer inflate the
+    quadratic remainder of a legitimate large soft-mode step. It is the
+    companion of the "Displacement" NR criterion, which measures the same
+    quantity.
+
+    Accepted on monotone decrease,
+    :math:`\|\bar{dX}(\alpha)\| \le (1 - c\,\alpha) \|dX\|`. The
+    contraction test of the theory (:math:`\theta \le 1 - \alpha/4`) assumes
+    the EXACT Jacobian; with a modified Newton tangent it rejects legitimate
+    steps down to alpha ~ 0, while monotonicity still catches an overshoot
+    (:math:`\theta > 1`).
+    """
+    if dx_norm == 0:
+        return True
+    dx_bar = pb._solve_reduced(res)
+    return np.linalg.norm(dx_bar, norm_type) <= (1.0 - _NATURAL_C * alpha) * dx_norm
 
 
 def line_search(pb, dX):
     """Line search to find an appropriate step size alpha.
 
-    To be assigned to self._step_size_callback. Two modes, selected by the
-    nr parameter "ls_mode" (see Problem.add_line_search):
+    To be assigned to self._step_size_callback. Three modes, selected by
+    the nr parameter "ls_mode" (see Problem.add_line_search):
 
-    - "safeguard" (default): pure validity filter (see below);
+    - "natural" (default): validity filter, then the trial step is accepted
+      when EITHER the Armijo residual test OR Deuflhard's affine-invariant
+      test passes (see _natural_test). The first one is the proven throttle
+      against the overshoot of penalty contact / elastic-plastic
+      transitions, the second one lets the legitimate large steps of soft
+      modes through. Backtracking as in "Quadratic".
     - "minimize": residual-descent methods (Residual, Armijo, Quadratic,
-      Energy), selected by the nr parameter "ls_method".
+      Energy), selected by the nr parameter "ls_method";
+    - "safeguard": pure validity filter.
     """
     if not pb._xbc_is_applied():
         # avoid using line_search if dirichlet increment values are not 0
@@ -73,23 +116,23 @@ def line_search(pb, dX):
         # control -- the most dangerous iterate for soft free modes.
         return 1
 
-    # --- Safeguard-first acceptance of the full Newton step -----------------
-    # The legitimate full Newton step of a soft mode can be LARGE (e.g. a
-    # 13 deg cap rotation towards a distant equilibrium): its quadratic
-    # remainder, amplified by the stiff nodal equations, grows the residual
-    # norm as step^2 (x10-x1000) while remaining an excellent step that the
-    # next iteration kills quadratically. Any residual-monotone rule then
-    # strangles Newton. Default policy ("safeguard"): the line search is a
-    # PURE VALIDITY FILTER (IPC-style) -- backtrack only on a degenerated
-    # trial state (det F <= 0 -> norm inf), with a 0.8 safety factor, and
-    # let the main loop's divergence detector handle true divergence.
-    # TODO(perf): in safeguard mode this full residual evaluation only
-    # tests det F > 0 -- when valid (the common case) its work is redone
-    # by the caller. A kinematics-only validity probe would remove one
-    # vector assembly + umat sweep per NR iteration.
-    ls_mode = pb.nr_parameters.get("ls_mode", "safeguard")
+    ls_mode = pb.nr_parameters.get("ls_mode", "natural")
+    norm_type = pb.nr_parameters["norm_type"]
+    # Residual of the current iterate (alpha = 0). MUST be read before any
+    # trial: _evaluate_residual_norm restores _dU, the state variables and D,
+    # but a constraint with _update_during_inc rebuilds B, _MatCB and
+    # _dof_free during the trial and those are NOT restored.
+    res_0 = pb._get_free_dof_residual()
+    norm_0 = np.linalg.norm(res_0, norm_type)
+
+    # --- Validity filter -----------------------------------------------------
+    # A trial state with det F <= 0 (norm inf) is rejected by geometric
+    # backtracking to the first VALID alpha, whatever the mode.
+    # TODO(perf): this full residual evaluation is, in safeguard mode, only
+    # a det F > 0 test whose work is redone by the caller when the step is
+    # valid (the common case). A kinematics-only validity probe would remove
+    # one vector assembly + umat sweep per NR iteration.
     norm_1, res_1 = _evaluate_residual_norm(pb, dX, 1.0)
-    # invalid full step: geometric backtracking to the first VALID alpha
     alpha_valid = 1.0
     while not np.isfinite(norm_1) and alpha_valid > 1e-4:
         alpha_valid *= 0.5
@@ -99,23 +142,25 @@ def line_search(pb, dX):
             return 1
         return max(0.8 * alpha_valid, 1e-4)
 
-    # --- minimize mode: residual-descent methods ---
-    method = pb.nr_parameters.get("ls_method", "Quadratic")
+    # --- Descent tests ---------------------------------------------------------
+    if ls_mode == "natural":
+        method = "Natural"
+    else:
+        method = pb.nr_parameters.get("ls_method", "Quadratic")
     alpha = alpha_valid
     rho = 0.5  # Standard backtracking contraction factor
-    c1 = 1e-4  # Armijo sufficient decrease constant
     max_iter = pb.nr_parameters.get("ls_max_iter", 5)
 
-    # --- Initial State Evaluation (alpha = 0) ---
-    norm_0, res_0 = _evaluate_residual_norm(pb, dX, 0)
     f_0 = 0.5 * (norm_0**2)
-
     # Directional derivative (assumes exact Newton step: dX = -J^-1 * R)
     m = -(norm_0**2)
 
-    if method == "Energy":
+    if method in ("Energy", "Natural"):
         dX_free = dX[pb._dof_free] if hasattr(pb, "_dof_free") else dX
+    if method == "Energy":
         work_0 = np.dot(res_0, dX_free)
+    elif method == "Natural":
+        dx_norm = np.linalg.norm(dX_free, norm_type)
 
     # Tracking the best step in case we exhaust max_iter. Start from the
     # last VALID alpha, never 1.0: if every trial below is invalid the
@@ -146,9 +191,13 @@ def line_search(pb, dX):
         if method == "Residual":
             if norm_alpha < norm_0:
                 return alpha
-        elif method in ["Armijo", "Quadratic"]:
-            # Both Armijo and Quadratic use the Armijo sufficient decrease rule
-            if f_alpha <= f_0 + c1 * alpha * m:
+        elif method in ["Armijo", "Quadratic", "Natural"]:
+            # Armijo sufficient decrease rule (Quadratic shares it)
+            if f_alpha <= f_0 + _ARMIJO_C1 * alpha * m:
+                return alpha
+            if method == "Natural" and _natural_test(
+                pb, res_alpha, dx_norm, alpha, norm_type
+            ):
                 return alpha
         elif method == "Energy":
             work_alpha = np.dot(res_alpha, dX_free)
@@ -156,7 +205,7 @@ def line_search(pb, dX):
                 return alpha
 
         # --- 2. Step Reduction Strategy (If rejected) ---
-        if method == "Quadratic":
+        if method in ["Quadratic", "Natural"]:
             # Calculate the vertex of the interpolating parabola
             denom = 2.0 * (f_alpha - f_0 - m * alpha)
 
@@ -175,5 +224,10 @@ def line_search(pb, dX):
             # Standard backtracking for Residual, Armijo, and Energy
             alpha *= rho
 
+    if method == "Natural":
+        # never fall back on the lowest-residual trial: that is precisely the
+        # merit this mode rejects for soft modes (it would return the most
+        # throttled alpha of the sweep). Keep the last kinematically valid one.
+        return alpha_valid
     # Criteria were not met within max_iter. Fallback to best alpha found.
     return best_alpha

--- a/fedoo/problem/linear.py
+++ b/fedoo/problem/linear.py
@@ -266,6 +266,15 @@ class Linear(Problem):
     def reset(self):
         self.__assembly.reset()
 
+        if self.is_dynamic:
+            # The transient effective (Newmark) matrix and the cached
+            # stiffness/mass/damping operators are rebuilt by initialize() on
+            # the next solve. Forcing the static stiffness here (and leaving
+            # _dynamic_initialized set) would silently run that solve on the
+            # static K with carried-over velocity/acceleration.
+            self._dynamic_initialized = False
+            return
+
         self.set_A(self.__assembly.get_global_matrix())  # tangent stiffness
         self.set_D(self.__assembly.get_global_vector())
         self.set_B(0)

--- a/fedoo/problem/non_linear.py
+++ b/fedoo/problem/non_linear.py
@@ -72,6 +72,10 @@ class _NonLinearBase:
         self.time = 0
         self.dtime = 0
         self._dtime_prev = 0  # dt of the last completed increment
+        # True while set_start closes an increment that has been solved
+        # (read by the time integrators, see set_start)
+        self._increment_solved = False
+        self._dU_old = 0  # last improving iterate, kept by adaptive_stiffness
         self.__iter = 0
         self.__compteurOutput = 0
 
@@ -301,7 +305,11 @@ class _NonLinearBase:
         # dt not used for static problem
         self._nr_min_subiter = 0  # reset SDI for new increment
         self._err0 = self.nr_parameters["err0"]  # initial error for NR error estimation
-        if not (np.isscalar(self._dU) and self._dU == 0):
+        # Tell the time integrators whether this call closes an increment that
+        # was actually solved: on an empty increment their recurrence would
+        # still consume one time step (for Newmark it negates the velocity).
+        self._increment_solved = not (np.isscalar(self._dU) and self._dU == 0)
+        if self._increment_solved:
             self._U += self._dU
             self._dU = 0
             self.__assembly.set_start(self)
@@ -325,6 +333,10 @@ class _NonLinearBase:
         self._t_fact_inc = None
         self._err0 = self.nr_parameters["err0"]  # initial error for NR error estimation
         self.__assembly.to_start(self)
+        # NB: the problem deliberately keeps the tangent of the diverged
+        # iterate here; the retry's elastic prediction reuses it (A != 0).
+        # Refreshing it from the restored assembly was tried and reverted: it
+        # drops the IPC contact block and breaks the punch benchmarks.
         self._run_constraint_hook("to_start")
 
     def update(self, compute="all", updateWeakForm=True):
@@ -542,7 +554,7 @@ class _NonLinearBase:
             # Multiple constraints exist: use the manager
             self._step_size_callback = _line_search_manager
 
-    def add_line_search(self, method="Quadratic", name=None, mode="safeguard"):
+    def add_line_search(self, method="Quadratic", name=None, mode="natural"):
         r"""Add line search algorithm for the Newton-Raphson solver.
 
         Line search improves global convergence by scaling the displacement
@@ -552,19 +564,33 @@ class _NonLinearBase:
 
         Parameters
         ----------
-        mode : {'safeguard', 'minimize'}, default 'safeguard'
+        mode : {'natural', 'minimize', 'safeguard'}, default 'natural'
             The overall line search policy:
 
-            * **'safeguard'** (default): pure validity filter. The full
-              Newton step is accepted whenever the trial state is
-              kinematically valid; geometric backtracking is applied only
-              on a degenerated trial state (:math:`\det F \le 0`). This
-              never throttles the legitimate large steps of soft modes
-              (whose quadratic remainder inflates the residual norm as
-              :math:`\alpha^2` while remaining excellent steps), which any
-              residual-monotone rule would strangle. ``method`` is ignored.
+            * **'natural'** (default): validity filter, then the step is
+              accepted when EITHER the classical Armijo test on
+              :math:`\|R\|` OR Deuflhard's affine-invariant test on the
+              simplified Newton correction :math:`K^{-1} R(u + \alpha dX)`
+              passes (see :func:`fedoo.problem.line_search._natural_test`).
+              The first one throttles the overshoot of penalty contact and
+              elastic-plastic transitions, the second one lets the
+              legitimate large steps of soft modes under force control
+              through. ``method`` is ignored. Factorization reuse
+              (:meth:`set_reuse_factorization`) is enabled automatically
+              with a direct solver so that each trial costs one
+              back-substitution.
             * **'minimize'**: classical residual-descent line search using
-              ``method`` below (the pre-safeguard behavior).
+              ``method`` below. Throttles the step against overshoot but
+              may strangle Newton on soft modes under force control.
+            * **'safeguard'**: pure validity filter. The full Newton step
+              is accepted whenever the trial state is kinematically valid;
+              geometric backtracking is applied only on a degenerated
+              trial state (:math:`\det F \le 0`). This never throttles the
+              legitimate large steps of soft modes (whose quadratic
+              remainder inflates the residual norm as :math:`\alpha^2`
+              while remaining excellent steps), which any residual-monotone
+              rule would strangle -- the right choice for force control of
+              soft (bending) modes. ``method`` is ignored.
         method : {'Armijo', 'Residual', 'Energy', 'Quadratic'} or callable, default 'Quadratic'
             The residual-descent strategy used when ``mode='minimize'``:
 
@@ -579,6 +605,16 @@ class _NonLinearBase:
             * **callable**: If a function is provided, it must follow the signature
               ``user_line_search(pb, dX) -> float`` and will be assigned directly
               as the line search callback (``mode`` is then ignored).
+
+              .. warning::
+                 A custom callback MUST return exactly 1 while a Dirichlet
+                 increment is still pending (test
+                 :meth:`_xbc_is_applied`, as the built-in line search does).
+                 A returned ``alpha < 1`` defers the remaining
+                 ``1 - alpha`` of the prescribed displacement to the next
+                 iterations, and convergence is only declared once nothing
+                 is left to apply: a callback that never returns 1 strands
+                 the increment and the time step collapses to ``dt_min``.
         name : str, optional
             A unique identifier for the line search. If not provided, it defaults
             to 'standard' for built-in methods, or the function's name for callables.
@@ -601,16 +637,20 @@ class _NonLinearBase:
 
         Example
         -------
-        >>> # Default validity safeguard
+        >>> # Default: natural monotonicity test
         >>> my_problem.add_line_search()
         >>> # Classical residual-descent line search
         >>> my_problem.add_line_search(mode="minimize", method="Quadratic")
+        >>> # Validity safeguard only (soft-mode force control)
+        >>> my_problem.add_line_search(mode="safeguard")
         >>> # Using a custom function
         >>> def my_ls(pb, dX): return 0.5
         >>> my_problem.add_line_search(method=my_ls)
         """
-        if mode not in ["safeguard", "minimize"]:
-            raise ValueError("Line search mode should be 'safeguard' or 'minimize'")
+        if mode not in ["natural", "minimize", "safeguard"]:
+            raise ValueError(
+                "Line search mode should be 'natural', 'minimize' or 'safeguard'"
+            )
         if callable(method):
             cb_name = name or getattr(method, "__name__", "custom_ls")
             self._ls_callbacks[cb_name] = method
@@ -645,6 +685,10 @@ class _NonLinearBase:
                     f"Line search '{name}' not found. No action taken.", UserWarning
                 )
 
+        if line_search not in self._ls_callbacks.values():
+            # solve_time_increment reads ls_mode to decide whether to enable
+            # factorization reuse: it must not outlive the line search
+            self.nr_parameters.pop("ls_mode", None)
         self._update_step_size_callback()
 
     def _get_free_dof_residual(self):
@@ -708,6 +752,8 @@ class _NonLinearBase:
             if self._err0 is None:
                 self._err0 = 1
                 self._err0 = self.compute_nr_error()
+                if self._err0 == 0:  # zero-work increment: keep a finite ref
+                    self._err0 = 1
                 return 1
             else:
                 if np.isscalar(self.get_D()) and self.get_D() == 0:
@@ -757,7 +803,8 @@ class _NonLinearBase:
             * 'dt_increase_niter': int or None, default = None.
               Number of nr iterations threshold that define an easy convergence.
               In problem allowing automatic convergence, if the Newton–Raphson
-              loop converges in strictly fewer iterations, the time step is increased.
+              loop converges in at most that many iterations, the time step is
+              increased.
               If None, defaults to max_subiter//3.
             * 'norm_type': int or numpy.inf, default = 2.
               Define the norm used to test the criterion.
@@ -780,10 +827,21 @@ class _NonLinearBase:
               max_subiter iterations are reached, regardless of tolerance criterion.
               Use only for special cases requiring forced convergence. Skips
               convergence tolerance check when iteration limit is reached.
-            * 'eigenvalue_shift': bool, default = False.
+            * 'eigenvalue_shift': bool, default = False. EXPERIMENTAL.
               If True, adds a shifted identity matrix to improve conditioning:
               A_eff = A + alpha*I where alpha = eigenvalue_shift_factor * R.
               R is estimated via Rayleigh quotient of the current stiffness.
+
+              .. warning::
+                 Known limitations, measured: the spectral estimate is run on
+                 the *unreduced* matrix, so it sees the modes of the blocked
+                 and rigid-body degrees of freedom rather than those of the
+                 system actually solved; and ``alpha*I`` is added before that
+                 reduction, which with multi-point constraints does not give
+                 ``reduced + alpha*I``. On a compressed buckling-prone plate
+                 the shift fired at 30 iterations without changing the
+                 iteration count at all. Treat it as a last resort, and
+                 prefer ``adaptive_stiffness`` or a dynamic solver.
             * 'eigenvalue_shift_factor': float, default = 1e-4.
               Scaling factor for the eigenvalue shift margin.
               Larger values = stronger stabilization but less accuracy.
@@ -796,7 +854,7 @@ class _NonLinearBase:
               If True, aborts the time step early if convergence trends are poor.
               A step is considered diverging if:
               1. The error remains "unproductive" (new_error > 0.999 * previous_error)
-                 for 3 consecutive Newton-Raphson iterations.
+                 for 4 consecutive Newton-Raphson iterations.
               2. The error spikes to more than 100 times the previous error.
         """
         if criterion not in ["Displacement", "Force", "Work"]:
@@ -832,6 +890,40 @@ class _NonLinearBase:
 
             self.nr_parameters[key] = kargs[key]
 
+    def _enable_factorization_reuse(self):
+        """Natural line search: make K^-1 R at trial states a back-substitution.
+
+        No-op with an iterative (or petsc) solver, which is left untouched:
+        the trials then re-solve the reduced system. NB: the reuse backend
+        follows the default direct priority (pypardiso > python-mumps >
+        petsc4py) whatever direct backend was forced with set_solver.
+        """
+        # only the default dispatch: a solver the user picked explicitly must
+        # not be silently swapped for the reuse backend
+        if self._factor_context is not None or self._solver_type != "direct":
+            return
+        try:
+            self.set_reuse_factorization(True)
+        except RuntimeError:  # no reuse backend installed (scipy only)
+            warnings.warn(
+                "natural line search: no factorization-reuse backend "
+                "(pypardiso, python-mumps or petsc4py); each line-search trial "
+                "will re-solve the tangent system.",
+                stacklevel=2,
+            )
+
+    def _elastic_reference_matrix(self, assemble=True):
+        """Return the "safe" fallback matrix of adaptive_stiffness.
+
+        Read from the CURRENT assembly: under ``nlgeom="UL"`` the reference
+        one holds the matrix of the undeformed configuration (and, for an
+        assembly sum, a state without the contact block), which would stay
+        frozen for the whole run.
+        """
+        if assemble:
+            self.assembly.current.assemble_global_mat("matrix")
+        return self.assembly.current.get_global_matrix()
+
     def _xbc_is_applied(self):
         """True when no Dirichlet increment remains to be applied.
 
@@ -845,7 +937,13 @@ class _NonLinearBase:
             return xbc == 0
         return not np.any(xbc)
 
-    def elastic_prediction(self):
+    def elastic_prediction(self, keep_tangent=False):
+        """Solve the elastic prediction of a new increment.
+
+        keep_tangent: do not touch the tangent matrix. Used by the
+        adaptive-stiffness restart, which has just installed the "safe"
+        elastic matrix on purpose.
+        """
         # update the boundary conditions with the time variation
         self._alpha = 1
         self.apply_boundary_conditions(self.t_fact, self.t_fact_old)
@@ -854,7 +952,22 @@ class _NonLinearBase:
         # matrix from the last converged iteration of the previous time step.
         # A new tangent matrix is computed only for the very first increment,
         # where the matrix has its initial value of 0.
-        if np.isscalar(self.get_A()) and self.get_A() == 0:
+        if keep_tangent:
+            pass
+        elif np.isscalar(self.get_A()) and self.get_A() == 0:
+            self._update_a()
+        elif self.time_integrators and self.dtime != self._dtime_prev:
+            # A transient tangent carries the 1/(beta dt^2) inertia term, so
+            # the matrix of the previous increment is wrong by (dt_prev/dt)^2
+            # once the time step changed -- x16 after the standard x0.25 cut,
+            # which wrecks the prediction exactly when the solver is already
+            # struggling. set_start/to_start have just re-assembled at the new
+            # dt, so this only installs that matrix. NB: gated on an actual
+            # integrator (the "compiled" flag is set even with none attached).
+            # Other dt-dependent tangents on a plain NonLinear -- the legacy
+            # ImplicitDynamic weak form, poromechanics, damping stabilization
+            # -- keep the previous behavior; covering them would need a
+            # `dt_dependent` property carried by the weak forms.
             self._update_a()
 
         self._update_d(
@@ -939,9 +1052,14 @@ class _NonLinearBase:
             )
 
         self._t_fact_inc = self.t_fact
+        if self.nr_parameters.get("ls_mode") == "natural":
+            self._enable_factorization_reuse()  # before the first solve
         if elastic_initial_guess or self._force_elastic_next_iter:
             # udpate assembly to the initial siffness given by the constitutive law
             self.assembly.current.assemble_global_mat("matrix")
+            # ... and hand it to the elastic prediction, which otherwise
+            # keeps the tangent of the previous iteration (A != 0)
+            self._update_a()
             if self._force_elastic_next_iter:
                 self._force_elastic_next_iter = (
                     False  # next iteration will be recomputed.
@@ -953,9 +1071,7 @@ class _NonLinearBase:
             # we take the assembled matrix computed after set_start and before
             # update. This should be the elastic or "safe" stiffness.
             # If not, adaptive_stiffness algorithm will not work as expected.
-            if not elastic_initial_guess:
-                self.assembly.current.assemble_global_mat("matrix")
-            KE = self.assembly.get_global_matrix()
+            KE = self._elastic_reference_matrix(assemble=not elastic_initial_guess)
             xi = 0.0
             xi_increased_this_step = False
 
@@ -1018,7 +1134,10 @@ class _NonLinearBase:
                 print(print_str)
 
             if adaptive_stiffness:
-                if consecutive_increases == 1:
+                if consecutive_increases == 0:
+                    # rolling backup of the last iterate that IMPROVED the
+                    # error: saving it once the error has already risen would
+                    # store the bad iterate the rollback below is meant to undo
                     self._dU_old = self._dU.copy()
                 if consecutive_increases >= 2 and xi < 1.0:
                     # Diverging - switch to elastic stiffness
@@ -1030,14 +1149,15 @@ class _NonLinearBase:
                     if subiter == 3:
                         # restart the iteration with the elastic stiffness
                         self.to_start()
+                        self._t_fact_inc = self.t_fact  # re-freeze (cleared above)
                         subiter = 1
                         error = float("inf")
                         self.set_A(KE)
-                        self.elastic_prediction()
+                        self.elastic_prediction(keep_tangent=True)
                         continue
                     else:
-                        # redo last iteration
-                        self._dU = self._dU_old
+                        # redo last iteration (copy: _dU is updated in place)
+                        self._dU = self._dU_old.copy()
                         subiter = max(subiter - 2, 1)
                         continue
                 elif consecutive_decreases > 0:
@@ -1079,9 +1199,19 @@ class _NonLinearBase:
 
             self.solve_nr_increment()
 
-        self._t_fact_inc = None
         if assume_cvg_at_max_subiter:
+            # the last correction was added to _dU without an update: bring
+            # the state variables (hence the outputs) to that iterate, with
+            # the load factor still frozen at the increment's target
+            try:
+                self.update(compute="vector")
+                self._update_d()
+            except InvalidKinematicStateError:
+                self._t_fact_inc = None
+                return 0, subiter, error
+            self._t_fact_inc = None
             return 1, subiter, error
+        self._t_fact_inc = None
         return 0, subiter, error
 
     def nlsolve(
@@ -1134,8 +1264,8 @@ class _NonLinearBase:
             (default = 10).
         dt_increase_niter: int, optional
             When ``update_dt`` is ``True``, the time increment is multiplied
-            by 1.25 if the Newton–Raphson loop converges in fewer
-            than ``dt_increase_niter`` iterations. If omitted, the
+            by 1.25 if the Newton–Raphson loop converges in at most
+            ``dt_increase_niter`` iterations. If omitted, the
             'dt_increase_niter' field in the nr_parameters attribute
             (ie nr_parameters['dt_increase_niter']) is considered
             (default = ``max_subiter // 3``).
@@ -1316,6 +1446,9 @@ class _NonLinearBase:
                         "Newton Raphson iteration has not converged - Reduce the time step or use update_dt = True"
                     )
 
+        # the last increment is finalized with its own dt (the loop-top value
+        # is that of the previous one, or of a failed attempt)
+        self._dtime_prev = self.dtime
         self.set_start(True, callback)
 
     @property

--- a/fedoo/problem/non_linear.py
+++ b/fedoo/problem/non_linear.py
@@ -5,6 +5,7 @@ from fedoo.core.assembly_sum import AssemblySum
 from fedoo.core.problem import Problem
 from fedoo.core.time_evolution import normalize_time_evolution
 from fedoo.problem.line_search import line_search, _line_search_manager
+from fedoo.core.base import InvalidKinematicStateError
 from scipy.sparse.linalg import eigs, eigsh, ArpackNoConvergence
 import warnings
 from typing import Callable
@@ -541,7 +542,7 @@ class _NonLinearBase:
             # Multiple constraints exist: use the manager
             self._step_size_callback = _line_search_manager
 
-    def add_line_search(self, method="Quadratic", name=None):
+    def add_line_search(self, method="Quadratic", name=None, mode="safeguard"):
         r"""Add line search algorithm for the Newton-Raphson solver.
 
         Line search improves global convergence by scaling the displacement
@@ -551,8 +552,21 @@ class _NonLinearBase:
 
         Parameters
         ----------
+        mode : {'safeguard', 'minimize'}, default 'safeguard'
+            The overall line search policy:
+
+            * **'safeguard'** (default): pure validity filter. The full
+              Newton step is accepted whenever the trial state is
+              kinematically valid; geometric backtracking is applied only
+              on a degenerated trial state (:math:`\det F \le 0`). This
+              never throttles the legitimate large steps of soft modes
+              (whose quadratic remainder inflates the residual norm as
+              :math:`\alpha^2` while remaining excellent steps), which any
+              residual-monotone rule would strangle. ``method`` is ignored.
+            * **'minimize'**: classical residual-descent line search using
+              ``method`` below (the pre-safeguard behavior).
         method : {'Armijo', 'Residual', 'Energy', 'Quadratic'} or callable, default 'Quadratic'
-            The strategy used to determine or refine the step size:
+            The residual-descent strategy used when ``mode='minimize'``:
 
             * **'Armijo'**: Ensures a "sufficient decrease" in the residual
               using a least-square assumption. Standard for most nonlinear applications.
@@ -564,7 +578,7 @@ class _NonLinearBase:
               function to jump directly to the estimated minimum.
             * **callable**: If a function is provided, it must follow the signature
               ``user_line_search(pb, dX) -> float`` and will be assigned directly
-              as the line search callback.
+              as the line search callback (``mode`` is then ignored).
         name : str, optional
             A unique identifier for the line search. If not provided, it defaults
             to 'standard' for built-in methods, or the function's name for callables.
@@ -572,8 +586,9 @@ class _NonLinearBase:
         Notes
         -----
         * **Implementation**: This method sets the `_step_size_callback` attribute
-          of the problem instance. Parameters like `ls_max_iter` and `ls_method`
-          are stored within the `self.nr_parameters` dictionary.
+          of the problem instance. Parameters `ls_mode`, `ls_method` and
+          `ls_max_iter` are stored within the `self.nr_parameters` dictionary
+          (they may also be set through :meth:`set_nr_criterion`).
         * **Objective Function**: For 'Armijo' and 'Quadratic' methods, the solver
           minimizes the squared L2-norm of the residual:
 
@@ -586,12 +601,16 @@ class _NonLinearBase:
 
         Example
         -------
-        >>> # Using a built-in method
-        >>> my_problem.add_line_search(method="Quadratic")
+        >>> # Default validity safeguard
+        >>> my_problem.add_line_search()
+        >>> # Classical residual-descent line search
+        >>> my_problem.add_line_search(mode="minimize", method="Quadratic")
         >>> # Using a custom function
         >>> def my_ls(pb, dX): return 0.5
         >>> my_problem.add_line_search(method=my_ls)
         """
+        if mode not in ["safeguard", "minimize"]:
+            raise ValueError("Line search mode should be 'safeguard' or 'minimize'")
         if callable(method):
             cb_name = name or getattr(method, "__name__", "custom_ls")
             self._ls_callbacks[cb_name] = method
@@ -606,6 +625,7 @@ class _NonLinearBase:
                 k: v for k, v in self._ls_callbacks.items() if v != line_search
             }
 
+            self.nr_parameters["ls_mode"] = mode
             self.nr_parameters["ls_method"] = method
             self._ls_callbacks[name or "standard"] = line_search
 
@@ -799,6 +819,9 @@ class _NonLinearBase:
             "check_early_divergence",
             "force_elastic_stiffness",
             "elastic_initial_guess",
+            "ls_mode",
+            "ls_method",
+            "ls_max_iter",
         ]
 
         for key in kargs:
@@ -808,6 +831,19 @@ class _NonLinearBase:
                 )
 
             self.nr_parameters[key] = kargs[key]
+
+    def _xbc_is_applied(self):
+        """True when no Dirichlet increment remains to be applied.
+
+        Under pure force control (or once the line search has fully applied
+        the scaled Dirichlet values), _Xbc is identically zero: convergence
+        may then be declared even if the line search kept returning
+        alpha < 1 (which leaves the _boundary_is_0 flag False forever).
+        """
+        xbc = self._Xbc
+        if np.isscalar(xbc):
+            return xbc == 0
+        return not np.any(xbc)
 
     def elastic_prediction(self):
         # update the boundary conditions with the time variation
@@ -929,7 +965,12 @@ class _NonLinearBase:
         error = float("inf")
         while subiter < max_subiter:
             # update Stress and initial displacement and Update stiffness matrix
-            self.update(compute="vector")  # update the out of balance force vector
+            try:
+                self.update(compute="vector")  # out of balance force vector
+            except InvalidKinematicStateError:
+                # the current iterate inverts elements: failed increment ->
+                # the caller cuts the time step and restores the state
+                return 0, subiter, error
             self._update_d()  # required to compute the NR error
 
             # Check convergence
@@ -938,7 +979,9 @@ class _NonLinearBase:
             if (
                 error < tol_nr
                 and subiter >= self._nr_min_subiter
-                and self._boundary_is_0
+                # NB: _boundary_is_0 True implies _Xbc was zeroed, so testing
+                # the actual _Xbc content subsumes the flag
+                and self._xbc_is_applied()
                 # constraints such as MeanMotion publish the out-of-balance on
                 # their own nonlinear equations here; gate convergence on it so
                 # an unsatisfied constraint cannot report a converged increment.

--- a/fedoo/time/base.py
+++ b/fedoo/time/base.py
@@ -1,9 +1,53 @@
 """Shared machinery for problem-level time integrators."""
 
+import warnings
+
 from fedoo.core.assembly import Assembly
 from fedoo.core.base import AssemblyBase
 from fedoo.core.time_evolution import normalize_time_evolution
 from fedoo.core.weakform import WeakFormSum
+
+_STAB_TOL = 1e-12
+
+
+def warn_if_conditionally_stable(beta, gamma, alpha_m=0.0, alpha_f=0.0, context=""):
+    """Warn when a Newmark / generalized-alpha set is only conditionally stable.
+
+    Unconditional (A-) stability of the generalized-alpha family
+    (Chung-Hulbert convention) requires::
+
+        alpha_m <= alpha_f <= 1/2
+        gamma >= 1/2 - alpha_m + alpha_f
+        beta >= gamma / 2
+
+    (Newmark is the ``alpha_m = alpha_f = 0`` special case.) A violating
+    set is CONDITIONALLY stable: with FE meshes (``omega_max*dt >> 1``) the
+    high-frequency modes grow geometrically and the solve collapses after a
+    few tens of increments regardless of dt or load level -- a failure that
+    masquerades as Newton divergence / element inversion.
+    """
+    prefix = f"{context}: " if context else ""
+    alpha_ordering_ok = alpha_m <= alpha_f + _STAB_TOL and alpha_f <= 0.5 + _STAB_TOL
+    if not alpha_ordering_ok:
+        warnings.warn(
+            f"{prefix}(alpha_m={alpha_m}, alpha_f={alpha_f}) violates "
+            "alpha_m <= alpha_f <= 1/2: the scheme is only CONDITIONALLY "
+            "stable.",
+            stacklevel=3,
+        )
+    gamma_min = 0.5 - alpha_m + alpha_f
+    if gamma < gamma_min - _STAB_TOL or beta < 0.5 * gamma - _STAB_TOL:
+        warnings.warn(
+            f"{prefix}(beta={beta}, gamma={gamma}) is only "
+            "CONDITIONALLY stable. Unconditional stability requires "
+            f"gamma >= {gamma_min} and beta >= gamma/2 = "
+            f"{0.5 * gamma:.4f} (recommended: beta = "
+            f"(gamma + 1/2)^2 / 4 = {0.25 * (gamma + 0.5) ** 2:.4f}"
+            " for oscillation-free high-frequency response). With "
+            "typical FE meshes the high-frequency modes will grow and "
+            "the solve will fail after a few tens of increments.",
+            stacklevel=3,
+        )
 
 
 class TimeIntegratorBase:

--- a/fedoo/time/common.py
+++ b/fedoo/time/common.py
@@ -150,6 +150,17 @@ def assemble_rayleigh_damping_matrix(
     return damping_matrix.tocsr()
 
 
+def increment_solved(pb):
+    """True when the problem's set_start closes an increment that was solved.
+
+    On an empty increment the Newmark recurrence is not the identity but
+    ``v <- v (1 - gamma/beta) + dt (1 - gamma/2beta) a``, i.e. exactly ``-v``
+    for the standard parameters, so it must not run. Drivers that do not
+    publish the flag are assumed to always close a solved increment.
+    """
+    return getattr(pb, "_increment_solved", True)
+
+
 def newmark_acceleration_velocity(beta, gamma, dt, delta_disp, v_n, a_n):
     """Newmark update of acceleration and velocity from a displacement increment.
 

--- a/fedoo/time/explicit.py
+++ b/fedoo/time/explicit.py
@@ -16,6 +16,14 @@ class ExplicitDynamicState:
     velocity: np.ndarray
     acceleration: np.ndarray
 
+    def copy(self):
+        """Return an independent copy of every kinematic field."""
+        return type(self)(
+            self.displacement.copy(),
+            self.velocity.copy(),
+            self.acceleration.copy(),
+        )
+
 
 class ExplicitAssemblyAdapter:
     """Mark an assembly-level provider for problem-driven explicit use.

--- a/fedoo/time/explicit.py
+++ b/fedoo/time/explicit.py
@@ -56,6 +56,17 @@ class ExplicitSecondOrderIntegrator(TimeIntegratorBase):
     evolution = SECOND_ORDER
     is_explicit = True
 
+    @property
+    def needs_end_step_acceleration(self):
+        """True when the driver must re-evaluate acceleration at ``u_{n+1}``.
+
+        Symplectic central difference (velocity Verlet) needs the acceleration
+        at the end-of-step displacement to close the velocity update. Schemes
+        that recover their end-step kinematics from the predictor alone return
+        ``False``.
+        """
+        return False
+
     def compile_assembly(self, assembly, evolution=None):
         """Register assembly-level storage while keeping static weakforms."""
         return super().compile_assembly(assembly, evolution)
@@ -159,6 +170,12 @@ class ExplicitGeneralizedAlpha(ExplicitSecondOrderIntegrator):
         if self.gamma <= 0.0:
             raise ValueError("gamma must be strictly positive.")
 
+    @property
+    def needs_end_step_acceleration(self):
+        # beta == 0 is explicit central difference: close velocity Verlet with
+        # the acceleration evaluated at the end-of-step displacement.
+        return self.beta == 0.0
+
     def predict(self, state, dt):
         displacement = (
             state.displacement
@@ -205,13 +222,18 @@ class ExplicitGeneralizedAlpha(ExplicitSecondOrderIntegrator):
     def state_from_displacement(self, state, predicted, displacement, dt):
         predicted_displacement, predicted_velocity = predicted
         if self.beta == 0.0:
-            base_displacement = (
-                state.displacement
-                + dt * state.velocity
-                - 0.5 * dt**2 * state.acceleration
+            # Central difference (velocity Verlet). The end-step acceleration
+            # a_{n+1} = M^-1 f(u_{n+1}) is evaluated at the new displacement by
+            # the problem driver, which then closes the velocity update
+            # v_{n+1} = v_n + 0.5*dt*(a_n + a_{n+1}). Only advance displacement
+            # here; keep the current velocity/acceleration as provisional values
+            # so the invariant ``state.acceleration == a_n = M^-1 f(u_n)`` holds
+            # when the driver reads a_n for the trapezoidal velocity update.
+            return ExplicitDynamicState(
+                displacement.copy(),
+                state.velocity.copy(),
+                state.acceleration.copy(),
             )
-            acceleration = (displacement - base_displacement) / dt**2
-            velocity = state.velocity + 0.5 * dt * (state.acceleration + acceleration)
         else:
             acceleration = (displacement - predicted_displacement) / (self.beta * dt**2)
             velocity = predicted_velocity + self.gamma * dt * acceleration

--- a/fedoo/time/generalized_alpha.py
+++ b/fedoo/time/generalized_alpha.py
@@ -12,6 +12,7 @@ from fedoo.time.common import (
     newmark_acceleration_velocity,
     resolve_dissipation,
     resolve_storage,
+    increment_solved,
 )
 
 
@@ -197,7 +198,9 @@ class GeneralizedAlphaAssemblyAdapter:
 
     def set_start(self, assembly, pb):
         dof_solution = pb.get_dof_solution()
-        if not (np.isscalar(dof_solution) and dof_solution == 0):
+        if increment_solved(pb) and not (
+            np.isscalar(dof_solution) and dof_solution == 0
+        ):
             dt = getattr(pb, "_dtime_prev", None) or pb.dtime
             if dt:
                 acc, vel = newmark_acceleration_velocity(
@@ -397,11 +400,15 @@ class GeneralizedAlphaStorageTerm(WeakFormBase):
             )
 
     def set_start(self, assembly, pb):
-        if not (np.isscalar(pb.get_dof_solution()) and pb.get_dof_solution() == 0):
+        if increment_solved(pb) and not (
+            np.isscalar(pb.get_dof_solution()) and pb.get_dof_solution() == 0
+        ):
             # _DeltaDisp was integrated over the increment that just completed,
             # so the recurrence must use that dt — pb.dtime already holds the
             # NEXT increment's step when set_start is called from nlsolve.
             dt = getattr(pb, "_dtime_prev", None) or pb.dtime
+            if not dt:  # no step yet: the recurrence would divide by zero
+                return
             acc, vel = _newmark_state(self, assembly, dt)
             assembly.sv["Velocity"] = vel
             assembly.sv["Acceleration"] = acc

--- a/fedoo/time/generalized_alpha.py
+++ b/fedoo/time/generalized_alpha.py
@@ -6,7 +6,7 @@ from scipy import sparse
 from fedoo.core._sparsematrix import scatter_dense_block
 from fedoo.core.time_evolution import SECOND_ORDER
 from fedoo.core.weakform import WeakFormBase, WeakFormSum
-from fedoo.time.base import TimeIntegratorBase
+from fedoo.time.base import TimeIntegratorBase, warn_if_conditionally_stable
 from fedoo.time.common import (
     RayleighDamping,
     newmark_acceleration_velocity,
@@ -257,6 +257,16 @@ class GeneralizedAlpha(TimeIntegratorBase):
             raise ValueError("beta must be strictly positive.")
         if self.gamma <= 0.0:
             raise ValueError("gamma must be strictly positive.")
+
+        # NB: the defaults (gamma = 1/2 - am + af, beta = (1 - am + af)^2 / 4)
+        # always satisfy the unconditional-stability conditions.
+        warn_if_conditionally_stable(
+            self.beta,
+            self.gamma,
+            alpha_m=self.alpha_m,
+            alpha_f=self.alpha_f,
+            context=type(self).__name__,
+        )
 
     def _compile_assembly_level_provider(self, assembly):
         if getattr(assembly, "time_evolution", None) != self.evolution:

--- a/fedoo/weakform/implicit_dynamic.py
+++ b/fedoo/weakform/implicit_dynamic.py
@@ -1,4 +1,5 @@
 from fedoo.core.weakform import WeakFormBase, WeakFormSum
+from fedoo.time.base import warn_if_conditionally_stable
 from fedoo.weakform.inertia import Inertia
 from fedoo.weakform.stress_equilibrium import StressEquilibrium
 
@@ -234,6 +235,10 @@ class ImplicitDynamic(ImplicitDynamicSum):
         nlgeom=False,
         space=None,
     ):
+        # Newmark = generalized-alpha with alpha_m = alpha_f = 0: warn on a
+        # conditionally stable (beta, gamma) pair (e.g. gamma=0.6 with the
+        # default-looking beta=0.25) -- see warn_if_conditionally_stable.
+        warn_if_conditionally_stable(beta, gamma, context="ImplicitDynamic")
         if isinstance(constitutivelaw, WeakFormBase):
             stiffness_weakform = constitutivelaw
         else:
@@ -247,7 +252,10 @@ class ImplicitDynamic(ImplicitDynamicSum):
         _NewmarkStiffness.__init__(stiffness_weakform, beta, gamma)
 
         time_integration = _NewmarkInertia(density, beta, gamma, "", nlgeom, space)
-        time_integration.assembly_options["assume_sym"] = True
+        # assume_sym is left unset so that both children share the same
+        # assembly grouping key (merged assembly); the stiffness weakform
+        # decides it at initialize (True except UL, where the Lie tangent is
+        # not major-symmetric).
         super().__init__([stiffness_weakform, time_integration], name)
 
 
@@ -287,6 +295,7 @@ class ImplicitDynamic2(WeakFormBase):
             constitutivelaw, stiffness_name, nlgeom, space
         )
         self.constitutivelaw = self.stiffness_weakform.constitutivelaw
+        warn_if_conditionally_stable(beta, gamma, context="ImplicitDynamic2")
         self.beta = beta
         self.gamma = gamma
         self.density = density

--- a/fedoo/weakform/implicit_dynamic.py
+++ b/fedoo/weakform/implicit_dynamic.py
@@ -48,7 +48,12 @@ class _NewmarkInertia(WeakFormBase):
     def set_start(self, assembly, pb):
         # This updates the historic variables to the newly converged step t
         dt = pb.dtime  # dt is the time step of the previous increment
-        if not (np.isscalar(pb.get_dof_solution()) and pb.get_dof_solution() == 0):
+        # deferred import: fedoo.time.common imports weak forms
+        from fedoo.time.common import increment_solved
+
+        if increment_solved(pb) and not (
+            np.isscalar(pb.get_dof_solution()) and pb.get_dof_solution() == 0
+        ):
             # update velocity and acceleration
             new_acceleration = (1 / (self.beta * dt**2)) * (
                 assembly.sv["_DeltaDisp"] - dt * assembly.sv["Velocity"]
@@ -340,7 +345,12 @@ class ImplicitDynamic2(WeakFormBase):
 
     def set_start(self, assembly, pb):
         dt = pb.dtime
-        if not (np.isscalar(pb.get_disp()) and pb.get_disp() == 0):
+        # deferred import: fedoo.time.common imports weak forms
+        from fedoo.time.common import increment_solved
+
+        if increment_solved(pb) and not (
+            np.isscalar(pb.get_disp()) and pb.get_disp() == 0
+        ):
             # update velocity and acceleration
             new_acceleration = (1 / (self.beta * dt**2)) * (
                 assembly.sv["_DeltaDisp"] - dt * assembly.sv["Velocity"]

--- a/fedoo/weakform/poromechanics.py
+++ b/fedoo/weakform/poromechanics.py
@@ -48,9 +48,13 @@ class PoroMomentum(StressEquilibriumMixed):
     Parameters
     ----------
     constitutivelaw : ConstitutiveLaw
-        Skeleton constitutive law. Must satisfy ``_Lt_from_F = True`` in
-        large-strain mode (this is the case for all simcoon hyperelastic
-        and visco-elastic laws).
+        Skeleton constitutive law. In large-strain mode it must be a
+        hyperelastic law whose tangent is computed from F
+        (``_Lt_from_F = True`` — the case for all simcoon hyperelastic and
+        visco-elastic laws). NB: the UL box -> Lie tangent conversion is
+        driven by the separate ``_corotational_box_tangent`` attribute
+        (True for every simcoon umat, see
+        :class:`fedoo.core.mechanical3d.Mechanical3D`).
     fluid_props : PoroFluidProperties
         Fluid-phase parameters. Only the Biot coefficient ``alpha`` is used
         here; ``PoroDarcy`` and ``PoroMassStorage`` use the other fields.

--- a/fedoo/weakform/stress_equilibrium.py
+++ b/fedoo/weakform/stress_equilibrium.py
@@ -1,7 +1,9 @@
 """The Strain equilibrium weak form from the fedoo finite element code."""
 
+import warnings
+
 from fedoo.core.weakform import WeakFormBase
-from fedoo.core.base import ConstitutiveLaw
+from fedoo.core.base import ConstitutiveLaw, InvalidKinematicStateError
 from fedoo.core.time_evolution import SECOND_ORDER
 from fedoo.weakform.inertia import Inertia
 from fedoo.util.voigt_tensors import StressTensorList, StrainTensorList
@@ -78,17 +80,20 @@ class StressEquilibrium(WeakFormBase):
               initial mesh with initial displacement effet)
         """
 
-        self.corate = "log"
-        # 'log': logarithmic strain, 'jaumann': jaumann strain,
-        # or 'green_naghdi', 'gn', 'log_inc'...
+        self.corate = "log_r"
+        # 'log_r' (default): logarithmic strain with the exact polar frame
+        # increment DR = R1 R0^T — the corate whose tangent transport is
+        # exact in simcoon, including with rotated internal-variable history.
+        # Other options: 'log' (XBM), 'jaumann', 'green_naghdi'/'gn',
+        # 'log_inc', 'log_r_inc'...
 
         self.fbar = False  # by default, the fbar stabilization is not used
         self.geometric_stiffness = False
 
-        self.assembly_options["assume_sym"] = True
-        # internalForce weak form should be symmetric
-        # (if TangentMatrix is symmetric)
-        # -> need to be checked for general case
+        # assume_sym is decided at initialize time: True for linear / TL
+        # (symmetric tangent), False for UL where the Lie spatial tangent is
+        # not major-symmetric. A user-set value takes precedence (with a
+        # warning if True is forced in UL).
 
     def get_storage(self):
         if self.storage is not None:
@@ -171,12 +176,30 @@ class StressEquilibrium(WeakFormBase):
         self.nlgeom = assembly._nlgeom
         self.corate = self._corate  # to force the setter function
 
-        # the UL spatial Cauchy tangent of a hyperelastic law is not
-        # major-symmetric (stress term), so it must not be symmetrized
+        # assume_sym: the UL spatial (Lie) tangent is not major-symmetric
+        # (stress terms), so the default is False in UL -- but only for laws
+        # that actually receive the box -> Lie conversion in update_2
+        # (native laws keep their symmetric engineering tangent).
+        # NB: the Assembly reads assume_sym at creation time, so the instance
+        # attribute must be set here as well.
+        user_sym = self.assembly_options.get("assume_sym")
         if assembly._nlgeom == "UL" and getattr(
-            self.constitutivelaw, "_Lt_from_F", False
+            self.constitutivelaw, "_corotational_box_tangent", False
         ):
-            self.assembly_options["assume_sym"] = False
+            if user_sym is True:
+                warnings.warn(
+                    "assume_sym=True with nlgeom='UL': the UL (Lie) tangent "
+                    "matrix is not major-symmetric; the assembled matrix "
+                    "will be symmetrized, which may degrade Newton "
+                    "convergence at large rotation.",
+                    stacklevel=2,
+                )
+            else:
+                self.assembly_options["assume_sym"] = False
+                assembly.assume_sym = False
+        elif user_sym is None:
+            self.assembly_options["assume_sym"] = True
+            assembly.assume_sym = True
 
         # Put the require field to zeros if they don't exist in the assembly
         if "Stress" not in assembly.sv:
@@ -269,7 +292,8 @@ class StressEquilibrium(WeakFormBase):
         stiffness matrix).
         """
         if assembly._nlgeom == "TL" or (
-            assembly._nlgeom == "UL" and self.constitutivelaw._Lt_from_F
+            assembly._nlgeom == "UL"
+            and getattr(self.constitutivelaw, "_corotational_box_tangent", False)
         ):
             # check if TangentMatrix has the consistent array shape
             if not isinstance(assembly.sv["TangentMatrix"], np.ndarray):
@@ -298,11 +322,17 @@ class StressEquilibrium(WeakFormBase):
             # simcoon UMATs return the "box" tangent d(tau_hat)/dD (Kirchhoff,
             # log rate); convert it to what this configuration integrates.
             if assembly._nlgeom == "TL":
-                # reference config: material tangent dS/dE (DsigmaDe_2_DSDE)
+                # reference config: PK2 feeds the TL residual (initial-stress
+                # term), so it must be updated even on line-search trials
                 assembly.sv["PK2"] = assembly.sv["Stress"].cauchy_to_pk2(
                     assembly.sv["F"]
                 )
+                if getattr(pb, "_line_search_update", False):
+                    # line-search trial: only the assembled vector is used,
+                    # skip the tangent conversion (same pattern as beam/plate)
+                    return
 
+                # material tangent dS/dE (DsigmaDe_2_DSDE)
                 assembly.sv["TangentMatrix"] = sim.Lt_convert(
                     assembly.sv["TangentMatrix"],
                     assembly.sv["F"],
@@ -310,26 +340,33 @@ class StressEquilibrium(WeakFormBase):
                     self._convert_Lt_tag,
                 )
 
-            elif self._convert_Lt_tag == "DSDE_2_Dsigma_logarithmicDD":
-                # current config, log rate: Cauchy tangent = Kirchhoff box / J
-                jacobian = np.linalg.det(assembly.sv["F"].transpose(2, 0, 1))
-                assembly.sv["TangentMatrix"] = (
-                    assembly.sv["TangentMatrix"] / jacobian[None, None, :]
-                )
-
-            else:  # UL jaumann / green_naghdi: box -> dS/dE -> spatial rate
+            else:
+                if getattr(pb, "_line_search_update", False):
+                    # line-search trial: only the assembled vector is used,
+                    # skip the tangent conversion (same pattern as beam/plate)
+                    return
+                # current config (UL), all corates (laws with a
+                # _corotational_box_tangent, i.e. simcoon umats): the box
+                # tangent d(tau_hat)/dD must be converted to the Lie
+                # (Truesdell) spatial tangent, which is the one consistent
+                # with the Cauchy-stress residual plus the standard
+                # initial-stress geometric term assembled here. Using the box
+                # (or box/J) directly leaves an O(sigma) inconsistency that
+                # destroys Newton convergence at large rotation (soft bending
+                # modes). _convert_Lt_tag holds the corate-specific
+                # box -> dS/dE first stage (see the corate setter).
                 stress = assembly.sv["Stress"].asarray()
                 dsde = sim.Lt_convert(
                     assembly.sv["TangentMatrix"],
                     assembly.sv["F"],
                     stress,
-                    "DsigmaDe_2_DSDE",
+                    self._convert_Lt_tag,
                 )
                 assembly.sv["TangentMatrix"] = sim.Lt_convert(
                     dsde,
                     assembly.sv["F"],
                     stress,
-                    self._convert_Lt_tag,
+                    "DSDE_2_Dsigma_LieDD",
                 )
 
     def to_start(self, assembly, pb):
@@ -373,7 +410,7 @@ class StressEquilibrium(WeakFormBase):
         op_grad_du = self.space.op_grad_u()
         # grad of displacement increment in incremental problems
 
-        if self.space.ndim == "3D":
+        if self.space.ndim == 3:
             # using voigt notation and with a 2 factor on non diagonal terms:
             # nl_strain_op_vir =
             #      0.5*(vir(duk/dxi) * duk/dxj + duk/dxi * vir(duk/dxj))
@@ -472,8 +509,13 @@ class StressEquilibrium(WeakFormBase):
         Properties defining the way strain is treated in finite strain problem
         (using a weakform with nlgeom = True)
         corate can take the following str values:
-            * "log" (default): exact logarithmic strain (strain is recomputed
-              at each iteration)
+            * "log_r" (default): exact logarithmic strain transported by the
+              exact polar rotation increment (strain is recomputed at each
+              iteration). This is the corate with an EXACT simcoon tangent
+              transport, including across committed increments with plastic
+              (or other rotated) history.
+            * "log": exact logarithmic strain, XBM logarithmic spin
+              transport (small tangent residual with rotated history)
             * "jaumann": Strain using the Jaumann derivative (strain is
               incremented)
             * "green_nagdhi" or "gn": Strain using the Green_Nagdhi derivative
@@ -486,25 +528,29 @@ class StressEquilibrium(WeakFormBase):
     def corate(self, value):
         self._corate = value
         if self.nlgeom == "UL":
+            # In UL, the assembled tangent is always the Lie (Truesdell)
+            # spatial tangent (see update_2); _convert_Lt_tag holds the
+            # corate-specific first-stage conversion of the umat box tangent
+            # d(tau_hat)/dD to the material tangent dS/dE.
             value = value.lower()
             if value == "log":
                 self._corate_func = _comp_log_strain
-                self._convert_Lt_tag = "DSDE_2_Dsigma_logarithmicDD"
+                self._convert_Lt_tag = "DsigmaDe_2_DSDE"
             elif value == "log_inc":
                 self._corate_func = _comp_log_strain_inc
-                self._convert_Lt_tag = "DSDE_2_Dsigma_logarithmicDD"
+                self._convert_Lt_tag = "DsigmaDe_2_DSDE"
             elif value in ["gn", "green_naghdi"]:
                 self._corate_func = _comp_gn_strain
-                self._convert_Lt_tag = "DSDE_2_Dsigma_GreenNaghdiDD"
+                self._convert_Lt_tag = "DsigmaDe_GreenNaghdiDD_2_DSDE"
             elif value == "jaumann":
                 self._corate_func = _comp_jaumann_strain
-                self._convert_Lt_tag = "DSDE_2_Dsigma_JaumannDD"
+                self._convert_Lt_tag = "DsigmaDe_JaumannDD_2_DSDE"
             elif value == "log_r":
                 self._corate_func = _comp_log_strain_R
-                self._convert_Lt_tag = "DSDE_2_Dsigma_logarithmicDD"
+                self._convert_Lt_tag = "DsigmaDe_2_DSDE"
             elif value == "log_r_inc":
                 self._corate_func = _comp_log_strain_R_inc
-                self._convert_Lt_tag = "DSDE_2_Dsigma_logarithmicDD"
+                self._convert_Lt_tag = "DsigmaDe_2_DSDE"
             else:
                 raise ValueError(
                     'corate value not understood. Choose between "log", "log_R", \
@@ -591,12 +637,41 @@ def _comp_grad_disp_fbar(assembly, displacement):
 
 
 # function to compute F tensor (required nl corate function used with simcoon)
+def _check_F_validity(F1):
+    """Reject degenerated trial kinematics (det F <= 0) as a recoverable error.
+
+    A Newton iterate that inverts elements must be treated as a FAILED step
+    (backtrack / time-step cut), never assembled: downstream, the polar
+    decomposition aborts and the assembled matrix fills with NaN (reported
+    by direct solvers as a spurious 'numerically singular').
+
+    Returns det F (per Gauss point) so callers can reuse it as J.
+    """
+    # explicit 3x3 cofactor expansion: ~10x faster than np.linalg.det on
+    # (3, 3, n_gp) arrays, and the result is reused as J by _comp_Fbar
+    det_f = (
+        F1[0, 0] * (F1[1, 1] * F1[2, 2] - F1[1, 2] * F1[2, 1])
+        - F1[0, 1] * (F1[1, 0] * F1[2, 2] - F1[1, 2] * F1[2, 0])
+        + F1[0, 2] * (F1[1, 0] * F1[2, 1] - F1[1, 1] * F1[2, 0])
+    )
+    min_det = det_f.min()
+    if not np.isfinite(min_det) or min_det <= 1e-12:
+        n_bad = int(np.count_nonzero(~(det_f > 1e-12)))
+        raise InvalidKinematicStateError(
+            f"trial state degenerates the kinematics: {n_bad} Gauss "
+            f"point(s) with det F <= 0 (min det F = {min_det:.3e}). "
+            "Treated as a failed Newton iterate."
+        )
+    return det_f
+
+
 def _comp_F(assembly, displacement):
     grad_values = _comp_grad_disp(assembly, displacement)
 
     eye_3 = np.empty((3, 3, 1), order="F")
     eye_3[:, :, 0] = np.eye(3)
     F1 = np.add(eye_3, grad_values, order="F")
+    _check_F_validity(F1)
     assembly.sv["F"] = F1
     if "F" not in assembly.sv_start:
         F0 = np.empty_like(F1)
@@ -612,8 +687,7 @@ def _comp_Fbar(assembly, displacement):
     eye_3 = np.empty((3, 3, 1), order="F")
     eye_3[:, :, 0] = np.eye(3)
     F1 = np.add(eye_3, grad_values, order="F")
-
-    J = np.linalg.det(F1.transpose((2, 0, 1)))
+    J = _check_F_validity(F1)
 
     grad_values_center = [
         [
@@ -624,7 +698,9 @@ def _comp_Fbar(assembly, displacement):
         ]
         for line_op in assembly.space.op_grad_u()
     ]
-    Jcenter = np.linalg.det(np.add(eye_3, grad_values_center).transpose((2, 0, 1)))
+    # the element-center Jacobian must be validated too: a negative Jcenter
+    # would silently turn the fractional power below into NaN
+    Jcenter = _check_F_validity(np.add(eye_3, grad_values_center))
     # Jcenter = np.mean(J.reshape(assembly.n_elm_gp, -1), axis=0)
     F1 = F1 * ((Jcenter / J.reshape(assembly.n_elm_gp, -1)).ravel() ** (1 / 3))
 

--- a/fedoo/weakform/stress_equilibrium_mixed.py
+++ b/fedoo/weakform/stress_equilibrium_mixed.py
@@ -1,6 +1,10 @@
 """Mixed Stress Equilibrium weak form."""
 
-from fedoo.weakform.stress_equilibrium import StressEquilibrium, _comp_grad_disp
+from fedoo.weakform.stress_equilibrium import (
+    StressEquilibrium,
+    _check_F_validity,
+    _comp_grad_disp,
+)
 import numpy as np
 
 
@@ -315,8 +319,9 @@ class StressEquilibriumMixed(StressEquilibrium):
         eye_3[:, :, 0] = np.eye(3)
         F1 = np.add(eye_3, grad_values, order="F")
 
-        # Calculate J and save its log for the pressure constraint
-        J = np.linalg.det(F1.transpose((2, 0, 1)))
+        # Reject inverted trial states (det F <= 0) BEFORE log(J) turns
+        # them into silent NaNs, then save ln J for the pressure constraint
+        J = _check_F_validity(F1)
         assembly.sv["lnJ"] = np.log(J)
 
         F1 = F1 * (J.reshape(assembly.n_elm_gp, -1).ravel() ** (-1 / 3))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-all = ['fedoo[solver,plot,test,ipc,io]']
+all = ['fedoo[solver,plot,test,ipc,io,identify]']
 io = ['meshio']
+identify = ['scikit-learn']
 ipc = ['ipctk>=1.6']
 solver = [
     'pypardiso ; platform_machine!="arm64" and platform_machine!="aarch64"',

--- a/tests/test_adaptive_stiffness_elastic_matrix.py
+++ b/tests/test_adaptive_stiffness_elastic_matrix.py
@@ -1,0 +1,50 @@
+"""The adaptive-stiffness fallback matrix must follow the current configuration.
+
+`solve_time_increment` captures a "safe" elastic matrix and installs it when
+the divergence guard restarts an increment. Reading it from the *reference*
+assembly froze it on the undeformed configuration under `nlgeom="UL"` -- and,
+for an assembly sum, on a state without the contact block. Since that matrix
+stays installed across the following time-step cuts, every retry failed at its
+first iteration with an infinite error, down to `dt_min`.
+"""
+
+import pytest
+
+import fedoo as fd
+
+
+def _stretched_ul_problem():
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("2Dplane")
+    mesh = fd.mesh.rectangle_mesh(4, 4, 0, 1, 0, 1, elm_type="quad4", name="sq")
+    material = fd.constitutivelaw.ElasticIsotrop(1e3, 0.3, name="law")
+    weakform = fd.weakform.StressEquilibrium(material, name="wf")
+    assembly = fd.Assembly.create(weakform, mesh, name="asm")
+    problem = fd.problem.NonLinear(assembly, nlgeom="UL")
+    problem.set_nr_criterion("Displacement", tol=1e-4, adaptive_stiffness=True)
+    problem.bc.add("Dirichlet", mesh.node_sets["bottom"], "Disp", 0)
+    problem.bc.add("Dirichlet", mesh.node_sets["top"], "Disp", [0.0, 0.3])
+    problem.nlsolve(dt=0.5, tmax=1.0, update_dt=False, print_info=0)
+    return problem, assembly
+
+
+def test_fallback_matrix_comes_from_the_current_assembly():
+    problem, assembly = _stretched_ul_problem()
+    assert assembly.current is not assembly  # UL works on a deformed copy
+
+    fallback = problem._elastic_reference_matrix()
+
+    assert fallback is assembly.current.get_global_matrix()
+    # the reference assembly still holds the undeformed matrix
+    assert abs(fallback - assembly.get_global_matrix()).max() > 0
+
+
+def test_fallback_matrix_can_skip_the_assembly_pass():
+    problem, assembly = _stretched_ul_problem()
+    problem.assembly.current.assemble_global_mat("matrix")
+    expected = assembly.current.get_global_matrix()
+    assert problem._elastic_reference_matrix(assemble=False) is expected
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_adaptive_stiffness_rollback.py
+++ b/tests/test_adaptive_stiffness_rollback.py
@@ -1,0 +1,64 @@
+"""adaptive_stiffness keeps the last IMPROVING iterate for its rollback.
+
+When the error rises twice in a row the solver switches to the elastic
+matrix and redoes the last iteration from `_dU_old`. That backup used to be
+taken once the error had already risen, i.e. it stored the very iterate the
+rollback is meant to undo -- and on a cleanly converging increment it was
+never taken at all. It is now refreshed on every iteration that improves the
+error.
+"""
+
+import numpy as np
+import pytest
+
+import fedoo as fd
+
+
+def _problem():
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("2Dplane")
+    mesh = fd.mesh.rectangle_mesh(3, 3, 0, 1, 0, 1, elm_type="quad4", name="sq")
+    material = fd.constitutivelaw.ElasticIsotrop(1e3, 0.3, name="law")
+    weakform = fd.weakform.StressEquilibrium(material, name="wf")
+    assembly = fd.Assembly.create(weakform, mesh, name="asm")
+    problem = fd.problem.NonLinear(assembly, nlgeom="UL")
+    problem.set_nr_criterion(
+        "Displacement", tol=1e-9, max_subiter=15, adaptive_stiffness=True
+    )
+    problem.bc.add("Dirichlet", mesh.node_sets["bottom"], "Disp", 0)
+    problem.bc.add("Dirichlet", mesh.node_sets["top"], "Disp", [0.15, 0.05])
+    return problem
+
+
+def _run_recording_backups(problem):
+    """Return the sequence of distinct `_dU_old` backups seen during a solve."""
+    backups = []
+    original = problem.compute_nr_error
+
+    def spy():
+        backup = problem._dU_old
+        if not np.isscalar(backup):
+            if not backups or not np.array_equal(backups[-1], backup):
+                backups.append(np.asarray(backup).copy())
+        return original()
+
+    problem.compute_nr_error = spy
+    problem.nlsolve(dt=1.0, tmax=1.0, update_dt=False, print_info=0)
+    return backups
+
+
+def test_backup_is_refreshed_on_every_improving_iteration():
+    problem = _problem()
+    backups = _run_recording_backups(problem)
+    # A cleanly converging increment only has improving iterations: the old
+    # rule (save when the error has risen) recorded none at all.
+    assert len(backups) >= 2
+    assert np.linalg.norm(backups[-1]) > 0
+
+
+def test_backup_is_unset_before_any_increment():
+    assert _problem()._dU_old == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_bc_duplicate_registration.py
+++ b/tests/test_bc_duplicate_registration.py
@@ -1,0 +1,72 @@
+"""Guard against double registration of the same BC object.
+
+A RigidTie explicitly added by the user AND auto-registered by a
+RigidBodyAssembly (constraint/rigid_body.py _register_global_dofs) used to
+end up TWICE in pb.bc: its MPCs were then duplicated, which silently
+corrupted the elimination (MatCB) and destroyed Newton convergence (the
+force-controlled cap benchmark diverged erratically from increment 4 with a
+perfectly consistent tangent). ListBC.add now ignores an object identical
+(by identity) to one already registered — in either registration order.
+"""
+
+import numpy as np
+import pytest
+
+simcoon = pytest.importorskip("simcoon")
+
+import fedoo as fd
+from fedoo.constraint.rigid_body import RigidBodyAssembly
+from fedoo.constraint.rigid_tie import RigidTie
+
+
+def _make_problem(add_tie_explicitly):
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("3D")
+    mesh = fd.mesh.box_mesh(nx=2, ny=2, nz=2, elm_type="hex8", name="box")
+    mat = fd.constitutivelaw.Simcoon("NEOHC", [3.0, 150.0], name="law")
+    mat.set_density(1000.0)
+    wf = fd.weakform.StressEquilibriumRI(mat, nlgeom="UL")
+    asm_fe = fd.Assembly.create(wf, mesh, name="fe")
+    tie = fd.constraint.RigidTie(mesh.find_nodes("Z", mesh.bounding_box.zmax))
+    rb = RigidBodyAssembly(
+        mass=0.01,
+        inertia_tensor=1e-6 * np.eye(3),
+        rigid_tie=tie,
+        mesh=mesh,
+        name="rb",
+    )
+    pb = fd.problem.NonLinear(asm_fe + rb)
+    pb.set_time_integrator(
+        fd.time.SECOND_ORDER, fd.time.Newmark(beta=0.3025, gamma=0.6)
+    )
+    if add_tie_explicitly:
+        pb.bc.add(tie)  # would duplicate without the ListBC.add identity guard
+    pb.bc.add("Dirichlet", mesh.find_nodes("Z", mesh.bounding_box.zmin), "Disp", 0)
+    pb.dtime = 0.01
+    pb.initialize()
+    return pb, tie
+
+
+@pytest.mark.parametrize("add_tie_explicitly", [True, False])
+def test_rigid_tie_registered_once(add_tie_explicitly):
+    pb, tie = _make_problem(add_tie_explicitly)
+    ties = [b for b in pb.bc if isinstance(b, RigidTie)]
+    assert len(ties) == 1
+    assert ties[0] is tie
+
+
+def test_double_add_same_object_is_ignored():
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("3D")
+    mesh = fd.mesh.box_mesh(nx=2, ny=2, nz=2, elm_type="hex8", name="box")
+    tie = fd.constraint.RigidTie(mesh.find_nodes("Z", mesh.bounding_box.zmax))
+    bcs = fd.core.boundary_conditions.ListBC()
+    bcs.add(tie)
+    bcs.add(tie)
+    bcs.append(tie)  # append is the guarded chokepoint (add goes through it)
+    bcs.extend([tie, tie])
+    assert sum(1 for b in bcs if b is tie) == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_explicit_dynamic_energy.py
+++ b/tests/test_explicit_dynamic_energy.py
@@ -1,0 +1,93 @@
+"""Energy conservation of the explicit central-difference integrator.
+
+An undamped, free-vibrating elastic bar must conserve total mechanical energy
+(kinetic + elastic) to :math:`O(\\Delta t^2)` under symplectic central
+difference. This pins the velocity-Verlet corrector: a stale end-of-step
+acceleration injects energy and the total diverges over many increments,
+whereas the correct scheme keeps it bounded.
+"""
+
+import numpy as np
+import pytest
+
+import fedoo as fd
+
+
+def _build_free_vibration_bar(dt, mass_lumping=True):
+    """Axial bar (nu=0), fixed at x=0, no external load, explicit dynamics."""
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("2Dplane")
+    E, nu, rho = 1.0, 0.0, 1.0
+    fd.mesh.rectangle_mesh(
+        nx=6,
+        ny=2,
+        x_min=0,
+        x_max=1.0,
+        y_min=0,
+        y_max=0.2,
+        elm_type="quad4",
+        name="Domain",
+    )
+    mesh = fd.Mesh["Domain"]
+    material = fd.constitutivelaw.ElasticIsotrop(E, nu, name="law")
+    material.set_density(rho)
+    fd.weakform.StressEquilibrium("law", name="wf")
+    fd.Assembly.create("wf", "Domain", "quad4", name="asm")
+    pb = fd.problem.ExplicitDynamic("asm", time_step=dt, mass_lumping=mass_lumping)
+    pb.bc.add("Dirichlet", mesh.find_nodes("X", 0.0), "Disp", 0)
+    return pb, mesh
+
+
+def _run_energy_history(dt, tmax, mass_lumping=True):
+    pb, mesh = _build_free_vibration_bar(dt, mass_lumping=mass_lumping)
+    # Velocity kick from the u=0 equilibrium: only the free nodes are set so the
+    # initial energy matches the constrained motion the driver actually runs.
+    fixed = mesh.find_nodes("X", 0.0)
+    velocity = 0.05 * np.ones(mesh.n_nodes)
+    velocity[fixed] = 0.0
+    pb.set_initial_velocity("DispX", velocity)
+    pb.initialize()
+
+    reference = pb.get_kinetic_energy() + pb.get_elastic_energy()
+    history = []
+
+    def record(problem):
+        history.append(problem.get_kinetic_energy() + problem.get_elastic_energy())
+
+    pb.solve_history(tmax=tmax, callback=record)
+    return reference, np.array(history)
+
+
+def test_central_difference_conserves_energy():
+    """Total energy must stay bounded over a long free-vibration history."""
+    reference, history = _run_energy_history(dt=0.02, tmax=20.0)
+
+    assert reference > 0.0
+    assert np.all(np.isfinite(history)), "energy diverged to a non-finite value"
+    # A stale end-step acceleration injects energy and the total blows up by
+    # many orders of magnitude; the symplectic scheme keeps it near reference.
+    assert history.max() < 1.1 * reference, (
+        f"total energy grew to {history.max():.3e} (reference {reference:.3e}): "
+        "the central-difference corrector is injecting energy"
+    )
+    drift = (history.max() - history.min()) / reference
+    assert drift < 0.1, f"energy drift {drift:.3e} too large for a symplectic scheme"
+
+
+def test_central_difference_conserves_energy_consistent_mass():
+    """Same guarantee with a consistent (non-lumped) mass matrix.
+
+    Exercises the mass-solve branch of the end-of-step acceleration, which the
+    lumped default (a diagonal divide) does not reach.
+    """
+    reference, history = _run_energy_history(dt=0.02, tmax=4.0, mass_lumping=False)
+
+    assert reference > 0.0
+    assert np.all(np.isfinite(history)), "energy diverged to a non-finite value"
+    assert (
+        history.max() < 1.1 * reference
+    ), f"total energy grew to {history.max():.3e} (reference {reference:.3e})"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_explicit_time_integrators.py
+++ b/tests/test_explicit_time_integrators.py
@@ -26,6 +26,7 @@ class _MatrixStorageAssembly(AssemblyBase):
         self.storage_calls = 0
         self.update_calls = 0
         self.set_start_calls = 0
+        self.velocity_bias = True
 
     @property
     def time_dof_indices(self):
@@ -42,7 +43,8 @@ class _MatrixStorageAssembly(AssemblyBase):
 
     def get_time_inertia_force(self, pb, acceleration, velocity):
         force = self._storage_matrix() @ acceleration
-        force[0] += velocity[0]
+        if self.velocity_bias:
+            force[0] += velocity[0]
         return force
 
     def initialize(self, pb):
@@ -68,6 +70,47 @@ class _MatrixStorageAssembly(AssemblyBase):
     def reset(self):
         self.global_matrix = None
         self.global_vector = None
+
+
+def _make_fe_problem(
+    *, young=0.0, density=1.0, dt=0.1, elm_type="tri3", mass_lumping=True
+):
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("2Dplane")
+    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type=elm_type)
+    material = fd.constitutivelaw.ElasticIsotrop(young, 0.3)
+    material.set_density(density)
+    assembly = fd.Assembly.create(fd.weakform.StressEquilibrium(material), mesh)
+    problem = fd.problem.ExplicitDynamic(
+        assembly,
+        time_step=dt,
+        mass_lumping=mass_lumping,
+    )
+    return problem, mesh
+
+
+def _make_storage_problem(dt=0.1):
+    space = fd.ModelingSpace("2Dplane")
+    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
+    assembly = _MatrixStorageAssembly(mesh, space)
+    return fd.problem.ExplicitDynamic(assembly, time_step=dt), assembly
+
+
+def test_explicit_dynamic_state_copy_is_independent():
+    state = ExplicitDynamicState(
+        displacement=np.array([1.0]),
+        velocity=np.array([2.0]),
+        acceleration=np.array([3.0]),
+    )
+
+    copied = state.copy()
+    copied.displacement[0] = 4.0
+    copied.velocity[0] = 5.0
+    copied.acceleration[0] = 6.0
+
+    np.testing.assert_allclose(state.displacement, [1.0])
+    np.testing.assert_allclose(state.velocity, [2.0])
+    np.testing.assert_allclose(state.acceleration, [3.0])
 
 
 def test_explicit_newmark_is_generalized_alpha_alias():
@@ -109,19 +152,9 @@ def test_explicit_generalized_alpha_uses_alpha_evaluation_state():
 
 
 def test_explicit_dynamic_preserves_constant_velocity_without_forces():
-    fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    material = fd.constitutivelaw.ElasticIsotrop(0.0, 0.3)
-    material.set_density(2.0)
-    weakform = fd.weakform.StressEquilibrium(material)
-    assembly = fd.Assembly.create(weakform, mesh)
-    problem = fd.problem.ExplicitDynamic(assembly, time_step=0.1)
+    problem, _ = _make_fe_problem(density=2.0)
     problem.set_initial_velocity("DispX", 1.0)
-    problem.initialize()
-
-    problem.apply_boundary_conditions()
-    problem.solve()
-    problem.update()
+    problem.solve_time_increment()
 
     np.testing.assert_allclose(problem.get_disp("DispX"), 0.1)
     np.testing.assert_allclose(problem.get_disp("DispY"), 0.0)
@@ -131,35 +164,66 @@ def test_explicit_dynamic_preserves_constant_velocity_without_forces():
 
 
 def test_central_difference_acceleration_opposes_elastic_displacement():
-    fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    material = fd.constitutivelaw.ElasticIsotrop(100.0, 0.3)
-    material.set_density(1.0)
-    weakform = fd.weakform.StressEquilibrium(material)
-    assembly = fd.Assembly.create(weakform, mesh)
-    problem = fd.problem.ExplicitDynamic(assembly, time_step=1.0e-3)
+    problem, mesh = _make_fe_problem(young=100.0, dt=1.0e-3)
 
     left = mesh.find_nodes("X", mesh.bounding_box.xmin)
     right = mesh.find_nodes("X", mesh.bounding_box.xmax)
     initial_x = np.zeros(mesh.n_nodes)
     initial_x[right] = 0.01
     problem.set_initial_displacement("DispX", initial_x)
-    problem.initialize()
     problem.bc.add("Dirichlet", left, "Disp", 0.0)
-
-    problem.apply_boundary_conditions()
-    problem.solve()
-    problem.update()
+    problem.solve_time_increment()
 
     assert np.all(problem.get_acceleration("DispX")[right] < 0.0)
     assert np.all(problem.get_velocity("DispX")[right] < 0.0)
 
 
+def test_central_difference_end_acceleration_includes_neumann_loads():
+    """The accepted acceleration must satisfy equilibrium with applied loads."""
+    problem, mesh = _make_fe_problem(elm_type="quad4")
+    right = mesh.find_nodes("X", mesh.bounding_box.xmax)
+    problem.bc.add("Neumann", right, "DispX", 1.0)
+
+    problem.solve_time_increment()
+
+    acceleration = problem.get_acceleration()
+    velocity = problem.get_velocity()
+    external_force = problem.get_B()
+    assert np.linalg.norm(acceleration) > 0.0
+    np.testing.assert_allclose(problem._mass_matrix @ acceleration, external_force)
+    np.testing.assert_allclose(velocity, problem.time_step * acceleration)
+
+
+def test_central_difference_end_acceleration_includes_rayleigh_damping():
+    """Damping must reduce both the accepted velocity and kinetic energy."""
+    problem, mesh = _make_fe_problem()
+    problem.set_initial_velocity("DispX", 1.0)
+    problem.set_rayleigh_damping(alpha=1.0, beta=0.0)
+
+    problem.solve_time_increment()
+
+    np.testing.assert_allclose(problem.get_velocity("DispX"), 0.905)
+    np.testing.assert_allclose(problem.get_acceleration("DispX"), -0.9)
+    initial_energy = 0.5 * np.sum(problem._mass[: mesh.n_nodes])
+    assert problem.get_kinetic_energy() < initial_energy
+
+
+def test_central_difference_updates_moving_dirichlet_kinematics_without_mpc():
+    """A prescribed displacement ramp must update constrained v and a."""
+    problem, mesh = _make_fe_problem(young=1.0, elm_type="quad4")
+    right = mesh.find_nodes("X", mesh.bounding_box.xmax)
+    problem.bc.add("Dirichlet", right, "DispX", 0.1)
+
+    problem.solve_time_increment(t_fact=1.0)
+
+    np.testing.assert_allclose(problem.get_disp("DispX")[right], 0.1)
+    np.testing.assert_allclose(problem.get_velocity("DispX")[right], 1.0)
+    np.testing.assert_allclose(problem.get_acceleration("DispX")[right], 10.0)
+
+
 def test_explicit_dynamic_uses_assembly_level_storage_matrix_directly():
-    space = fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    assembly = _MatrixStorageAssembly(mesh, space)
-    problem = fd.problem.ExplicitDynamic(assembly, time_step=0.1)
+    problem, assembly = _make_storage_problem()
+    assembly.velocity_bias = False
 
     problem.initialize()
     problem.apply_boundary_conditions()
@@ -172,11 +236,8 @@ def test_explicit_dynamic_uses_assembly_level_storage_matrix_directly():
 
 
 def test_explicit_dynamic_uses_assembly_inertia_force_callback():
-    space = fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    assembly = _MatrixStorageAssembly(mesh, space)
-    problem = fd.problem.ExplicitDynamic(assembly, time_step=0.1)
-    initial_velocity = np.zeros(mesh.n_nodes)
+    problem, _ = _make_storage_problem()
+    initial_velocity = np.zeros(problem.mesh.n_nodes)
     initial_velocity[0] = 1.0
     problem.set_initial_velocity("DispX", initial_velocity)
 
@@ -189,11 +250,8 @@ def test_explicit_dynamic_uses_assembly_inertia_force_callback():
 
 
 def test_explicit_dynamic_refreshes_configuration_dependent_storage():
-    space = fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    assembly = _MatrixStorageAssembly(mesh, space)
+    problem, assembly = _make_storage_problem()
     assembly.storage_matrix_is_constant = False
-    problem = fd.problem.ExplicitDynamic(assembly, time_step=0.1)
 
     problem.initialize()
     assert assembly.storage_calls == 1
@@ -203,11 +261,8 @@ def test_explicit_dynamic_refreshes_configuration_dependent_storage():
     assert assembly.storage_calls == 2
 
 
-def test_manual_linear_step_does_not_update_or_commit_assembly():
-    space = fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    assembly = _MatrixStorageAssembly(mesh, space)
-    problem = fd.problem.ExplicitDynamic(assembly, time_step=0.1)
+def test_manual_steps_control_assembly_update_and_commit():
+    problem, assembly = _make_storage_problem()
 
     problem.initialize()
     problem.apply_boundary_conditions()
@@ -217,17 +272,6 @@ def test_manual_linear_step_does_not_update_or_commit_assembly():
     assert assembly.update_calls == 1
     assert assembly.set_start_calls == 0
 
-    problem.set_start()
-    assert assembly.set_start_calls == 1
-
-
-def test_update_can_refresh_weakform_at_committed_state():
-    space = fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    assembly = _MatrixStorageAssembly(mesh, space)
-    problem = fd.problem.ExplicitDynamic(assembly, time_step=0.1)
-
-    problem.initialize()
     problem.apply_boundary_conditions()
     problem.solve()
     problem.update(update_weakform=True)
@@ -235,12 +279,12 @@ def test_update_can_refresh_weakform_at_committed_state():
     assert assembly.update_calls == 2
     assert assembly.set_start_calls == 0
 
+    problem.set_start()
+    assert assembly.set_start_calls == 1
+
 
 def test_matrix_only_update_discards_cached_internal_force():
-    space = fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    assembly = _MatrixStorageAssembly(mesh, space)
-    problem = fd.problem.ExplicitDynamic(assembly, time_step=0.1)
+    problem, _ = _make_storage_problem()
 
     problem.initialize()
     problem.apply_boundary_conditions()
@@ -251,45 +295,37 @@ def test_matrix_only_update_discards_cached_internal_force():
 
 
 def test_solve_time_increment_manages_nonlinear_update_and_commit():
-    space = fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    assembly = _MatrixStorageAssembly(mesh, space)
-    problem = fd.problem.ExplicitDynamic(assembly, time_step=0.1)
+    problem, assembly = _make_storage_problem()
 
     problem.initialize()
     problem.solve_time_increment(update_weakform=True, set_start=True)
 
-    assert assembly.update_calls == 3
+    # Initialization and the accepted end state are each assembled once. The
+    # initial force is reused for evaluation instead of being assembled twice.
+    assert assembly.update_calls == 2
     assert assembly.set_start_calls == 1
     assert problem.time == 0.1
 
 
 def test_solve_history_selects_fixed_or_updated_weakform():
-    space = fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    linear_assembly = _MatrixStorageAssembly(mesh, space)
-    linear = fd.problem.ExplicitDynamic(linear_assembly, time_step=0.1)
+    linear, linear_assembly = _make_storage_problem()
     linear.solve_history(tmax=0.2, update_weakform=False)
 
     assert linear_assembly.update_calls == 1
     assert linear_assembly.set_start_calls == 0
     assert linear.time == 0.2
 
-    nonlinear_assembly = _MatrixStorageAssembly(mesh, space)
-    nonlinear = fd.problem.ExplicitDynamic(nonlinear_assembly, time_step=0.1)
+    nonlinear, nonlinear_assembly = _make_storage_problem()
     nonlinear.solve_history(tmax=0.2, update_weakform=True)
 
-    assert nonlinear_assembly.update_calls == 5
+    assert nonlinear_assembly.update_calls == 3
     assert nonlinear_assembly.set_start_calls == 2
     assert nonlinear.time == 0.2
 
 
 def test_solve_history_saves_at_exact_time_intervals():
     for update_weakform in (False, True):
-        space = fd.ModelingSpace("2Dplane")
-        mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-        assembly = _MatrixStorageAssembly(mesh, space)
-        problem = fd.problem.ExplicitDynamic(assembly, time_step=0.03)
+        problem, assembly = _make_storage_problem(dt=0.03)
         saved = []
         problem.save_results = lambda iteration: saved.append((iteration, problem.time))
 
@@ -305,43 +341,6 @@ def test_solve_history_saves_at_exact_time_intervals():
         )
         assert [iteration for iteration, _ in saved] == [0, 1, 2]
         assert problem.time_step == 0.03
-
-
-def test_fixed_solve_history_refreshes_assembly_only_at_output_times():
-    space = fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    assembly = _MatrixStorageAssembly(mesh, space)
-    problem = fd.problem.ExplicitDynamic(assembly, time_step=0.03)
-    problem.save_results = lambda iteration: None
-
-    problem.solve_history(
-        tmax=0.25,
-        update_weakform=False,
-        interval_output=0.1,
-    )
-
-    assert assembly.update_calls == 4
-
-
-def test_explicit_dynamic_has_one_complete_history_api():
-    assert hasattr(fd.problem.ExplicitDynamic, "solve_history")
-    assert not hasattr(fd.problem.ExplicitDynamic, "lsolve")
-    assert not hasattr(fd.problem.ExplicitDynamic, "nlsolve")
-
-
-def test_consistent_fe_mass_can_be_kept_without_lumping():
-    fd.ModelingSpace("2Dplane")
-    mesh = fd.mesh.rectangle_mesh(nx=2, ny=2, elm_type="tri3")
-    material = fd.constitutivelaw.ElasticIsotrop(1.0, 0.3)
-    material.set_density(1.0)
-    weakform = fd.weakform.StressEquilibrium(material)
-    assembly = fd.Assembly.create(weakform, mesh)
-    problem = fd.problem.ExplicitDynamic(
-        assembly,
-        time_step=0.1,
-        mass_lumping=False,
-    )
-
-    problem.initialize()
-
-    assert problem.get_A().ndim == 2
+        if not update_weakform:
+            # Initialization plus one vector refresh at each saved output.
+            assert assembly.update_calls == 4

--- a/tests/test_finite_strain_tangent_consistency.py
+++ b/tests/test_finite_strain_tangent_consistency.py
@@ -1,0 +1,423 @@
+"""Finite-difference consistency of the finite-strain global tangent.
+
+Guards two historical defects of the 3D finite-strain path:
+
+1. ``_init_nl_strain_op_vir`` compared ``space.ndim`` (an int) to the string
+   ``"3D"``, so every 3D problem silently used the 2D-truncated geometric
+   stiffness: all initial-stress terms involving a Z derivative (S33, S13,
+   S23 slots and the k=Z rows) were missing. The tangent error was O(sigma),
+   grew with load, and destroyed Newton on soft (bending) modes -- e.g. the
+   NEOHC cantilever stalled at 0.82 L with a contraction rate ~0.85.
+
+2. The UL log-corate branch used the umat box tangent divided by J as the
+   spatial tangent. The tangent consistent with the Cauchy residual plus the
+   standard initial-stress term is the Lie (Truesdell) one:
+   box -> dS/dE -> DSDE_2_Dsigma_LieDD.
+
+The check: on a hex8 box at 10% stretch, the assembled tangent must match the
+central finite difference of the assembled global vector to ~1e-6 in relative
+directional norm. With defect (1) the error is ~3e-3; machine-accurate
+assembly gives ~1e-8.
+
+The ELISO / EPICP cases (and the log_R corate) additionally require simcoon's
+EXACT spectral log-box tangent transport (Daleckii-Krein maps in Lt_convert,
+shipped after 2.0.0b1): with the earlier first-order (frozen-spin) transport
+they sit at ~2e-3. They are gated by a runtime capability probe rather than a
+version compare (see _simcoon_exact_log_transport).
+
+HISTORY TRANSPORT (resolved 2026-09-01): the missing term at large rotation
+was NOT the kernel's rotated-history sensitivity but the FRAME of the box
+tangent inside simcoon's exact transport: the spatial-frame Lt was applied
+to the material-frame d(ln U) without the polar-rotation conjugation
+R^T (Lt : R dh R^T) R -- invisible for isotropic Lt (ELISO) or R ~ I
+(stretch tests), O(||Lt_dev|| * theta_R) for a plastified box tangent under
+accumulated rotation.  With the conjugated map plus the exact polar frame
+increment DR = R1 R0^T in simcoon's log_R kinematics, the multi-increment
+assembled tangent is FD-exact (~2e-8 through gamma = 0.3 committed shear)
+and EPICP Newton stays flat at 4 iters/increment through gamma = 0.4
+(before: 5 -> 18 over 0 -> 0.2, subiter exhaustion ~0.3).  The
+multi-increment case is gated by _simcoon_exact_history_transport.
+
+KNOWN LIMIT: with corate "log" (XBM) the frame increment is the XBM spin
+integral, which is not exactly equivariant under superposed rotation; with
+plastic history this leaves a genuine O(||EP|| * dtheta) tangent residual
+(~1e-4 at gamma1 = 0.1, ~1e-3 at 0.3 -- harmless to Newton in practice:
+iteration counts stay flat).  The multi-increment test therefore locks
+corate log_R only.
+"""
+
+import functools
+
+import numpy as np
+import pytest
+from scipy.linalg import logm, sqrtm
+
+simcoon = pytest.importorskip("simcoon")
+
+import fedoo as fd
+
+MU, KAPPA = 3.0, 150.0
+STRETCH = 0.10
+# EPICP: E, nu, alpha, sigma_Y, k, m -- 10% stretch drives far beyond the
+# 200 MPa yield (yield strain ~0.3%), so the box tangent is the evolving
+# elastoplastic one, which is what the exact transport is really for.
+EPICP_PROPS = [70000.0, 0.3, 1e-5, 200.0, 1000.0, 0.3]
+
+_VOIGT = [(0, 0), (1, 1), (2, 2), (0, 1), (0, 2), (1, 2)]
+
+
+def _sig_to_mat(s):
+    """Voigt stress 6-vector -> symmetric 3x3 matrix."""
+    return np.array([[s[0], s[3], s[4]], [s[3], s[1], s[5]], [s[4], s[5], s[2]]])
+
+
+def _box_tangent_pk2_fd_error(call, F):
+    """Rel. error of Lt_convert("DsigmaDe_2_DSDE") vs central FD of S(E).
+
+    ``call(F) -> (s6, sig_mat, Lt)`` is a one-shot material-point umat
+    evaluation returning the Cauchy stress (6-vector and matrix) and the
+    corotational box tangent. Shared by both capability probes.
+    """
+
+    def pk2(E):
+        F_ = np.real(sqrtm(2 * E + np.eye(3)))
+        _, sig_mat, _ = call(F_)
+        Fi = np.linalg.inv(F_)
+        return np.linalg.det(F_) * Fi @ sig_mat @ Fi.T
+
+    E0 = 0.5 * (F.T @ F - np.eye(3))
+    s6, _, Lt = call(F)
+    dsde = simcoon.Lt_convert(
+        np.asfortranarray(Lt.reshape(6, 6, 1)),
+        np.asfortranarray(F.reshape(3, 3, 1)),
+        np.asfortranarray(np.asarray(s6).reshape(6, 1)),
+        "DsigmaDe_2_DSDE",
+    )[:, :, 0]
+    h = 1e-7
+    fd_mat = np.zeros((6, 6))
+    for j, (k, l) in enumerate(_VOIGT):
+        dE = np.zeros((3, 3))
+        dE[k, l] = dE[l, k] = h
+        dS = (pk2(E0 + dE) - pk2(E0 - dE)) / (2 * h)
+        col = np.array([dS[0, 0], dS[1, 1], dS[2, 2], dS[0, 1], dS[0, 2], dS[1, 2]])
+        fd_mat[:, j] = col if j < 3 else col / 2.0
+    return np.abs(dsde - fd_mat).max() / np.abs(fd_mat).max()
+
+
+def _directional_fd_error(pb, assembly, free, n_dir=3, eps=1e-8):
+    """Max rel. error of K vs central FD of the assembled global vector.
+
+    Probes ``n_dir`` random directions restricted to the ``free`` dofs,
+    around the current converged state of ``pb``.
+    """
+    U0 = np.asarray(pb._U + (0 if np.isscalar(pb._dU) else pb._dU)).copy()
+    pb._U = U0.copy()
+    pb._dU = 0
+    assembly.update(pb, "all")
+    K = assembly.current.get_global_matrix().tocsr()
+
+    rng = np.random.default_rng(0)
+    errors = []
+    for _ in range(n_dir):
+        delta = np.zeros(K.shape[0])
+        delta[free] = rng.standard_normal(len(free))
+        delta /= np.abs(delta).max()
+        r = []
+        for sgn in (1, -1):
+            pb._U = U0 + sgn * eps * delta
+            pb._dU = 0
+            assembly.update(pb, "vector")
+            r.append(np.asarray(assembly.current.get_global_vector()).ravel().copy())
+        fd_dir = (r[0] - r[1]) / (2 * eps)
+        Kd = np.asarray(K @ delta).ravel()
+        # fedoo assembles -residual in the global vector
+        errors.append(
+            np.linalg.norm(fd_dir[free] + Kd[free]) / np.linalg.norm(Kd[free])
+        )
+    return max(errors)
+
+
+@functools.lru_cache(maxsize=1)
+def _simcoon_exact_log_transport():
+    """True when simcoon ships the exact log-box tangent transport.
+
+    Capability probe (material point): one-shot ELISO at a rotation-free
+    stretched state; the chain umat-box -> Lt_convert("DsigmaDe_2_DSDE") must
+    match the FD of S(E) to ~1e-9. The first-order (frozen-spin) transport of
+    simcoon <= 2.0.0b1 gives ~2e-3 here. A version compare is not usable:
+    the installed metadata may lag the fix (dev builds report 0+unknown).
+    TODO: once the simcoon release containing the fix has a number (TBD),
+    bump the pyproject pin to it and replace this probe by that requirement.
+    """
+    props = np.asfortranarray(np.array([[8.7], [0.49], [1e-5]]))
+
+    def call(F):
+        F_ = np.asfortranarray(F.reshape(3, 3, 1))
+        F0 = np.asfortranarray(np.eye(3).reshape(3, 3, 1))
+        z6 = np.zeros((6, 1), order="F")
+        DR = np.asfortranarray(np.eye(3).reshape(3, 3, 1))
+        statev = np.zeros((1, 1), order="F")
+        wm = np.zeros((4, 1), order="F")
+        temp = np.zeros((1, 1), order="F")
+        C = F.T @ F
+        w, v = np.linalg.eigh(C)
+        e = v @ np.diag(0.5 * np.log(w)) @ v.T
+        de = np.asfortranarray(
+            np.array(
+                [e[0, 0], e[1, 1], e[2, 2], 2 * e[0, 1], 2 * e[0, 2], 2 * e[1, 2]]
+            ).reshape(6, 1)
+        )
+        sig, _, _, Lt = simcoon.umat(
+            "ELISO",
+            z6,
+            de,
+            F0,
+            F_,
+            z6,
+            DR,
+            props,
+            statev,
+            0.0,
+            1.0,
+            wm,
+            temp,
+            ndi=3,
+            tangent_mode=1,
+        )
+        s = sig[:, 0]
+        return s, _sig_to_mat(s), (Lt[:, :, 0] if Lt.ndim == 3 else Lt)
+
+    Fb = np.array([[1.08, 0.04, 0.0], [0.0, 0.96, 0.0], [0.0, 0.0, 0.99]])
+    Fb = np.real(sqrtm(Fb @ Fb.T))
+    return _box_tangent_pk2_fd_error(call, Fb) < 1e-6
+
+
+requires_exact_transport = pytest.mark.skipif(
+    not _simcoon_exact_log_transport(),
+    reason=(
+        "installed simcoon lacks the exact log-box tangent transport "
+        "(first-order transport <= 2.0.0b1); bump the simcoon pin to the "
+        "release containing it (number TBD) and drop this guard"
+    ),
+)
+
+
+@functools.lru_cache(maxsize=1)
+def _simcoon_exact_history_transport():
+    """True when the exact transport also carries the rotation of the box.
+
+    Discriminating probe (material point): ONE virgin EPICP increment of
+    simple shear gamma = 0.3 (rotation-carrying, plastified, so the box
+    tangent is anisotropic while the history is still zero).  The chain
+    umat-box -> Lt_convert("DsigmaDe_2_DSDE") must match the FD of S(E) to
+    ~1e-8.  Without the polar conjugation of the box inside the exact map
+    (simcoon <= the 2026-09-01 fix) this sits at ~5e-3 even though
+    _simcoon_exact_log_transport passes (its probe is rotation-free).
+    """
+    props = np.asfortranarray(np.c_[EPICP_PROPS].astype(float))
+
+    def call(F):
+        lnV = 0.5 * np.real(logm(F @ F.T))
+        de = np.array(
+            [
+                lnV[0, 0],
+                lnV[1, 1],
+                lnV[2, 2],
+                2 * lnV[0, 1],
+                2 * lnV[0, 2],
+                2 * lnV[1, 2],
+            ]
+        )
+        F0 = np.asfortranarray(np.eye(3).reshape(3, 3, 1))
+        _, DR, _ = simcoon.objective_rate(
+            "log_R", F0, np.asfortranarray(F.reshape(3, 3, 1)), 1.0, False
+        )
+        z6 = np.zeros((6, 1), order="F")
+        sig, _, _, Lt = simcoon.umat(
+            "EPICP",
+            z6,
+            np.asfortranarray(de.reshape(6, 1)),
+            F0,
+            np.asfortranarray(F.reshape(3, 3, 1)),
+            z6,
+            np.asfortranarray(DR),
+            props,
+            np.zeros((8, 1), order="F"),
+            0.0,
+            1.0,
+            np.zeros((4, 1), order="F"),
+            np.zeros((1, 1), order="F"),
+            ndi=3,
+            tangent_mode=2,
+        )
+        s = sig[:, 0]
+        return s, _sig_to_mat(s), (Lt[:, :, 0] if Lt.ndim == 3 else Lt)
+
+    F1 = np.eye(3)
+    F1[0, 1] = 0.3
+    return _box_tangent_pk2_fd_error(call, F1) < 1e-6
+
+
+requires_exact_history_transport = pytest.mark.skipif(
+    not _simcoon_exact_history_transport(),
+    reason=(
+        "installed simcoon lacks the rotation-conjugated exact transport + "
+        "exact polar log_R frame increment (2026-09-01 fix); bump the "
+        "simcoon pin to the release containing it (number TBD) and drop "
+        "this guard"
+    ),
+)
+
+
+def _fd_tangent_error(nlgeom, law="NEOHC", corate=None):
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("3D")
+    mesh = fd.mesh.box_mesh(nx=2, ny=2, nz=2, elm_type="hex8", name="box")
+
+    if law == "NEOHC":
+        material = fd.constitutivelaw.Simcoon("NEOHC", [MU, KAPPA], name="law")
+    elif law == "ELISO":
+        # hypoelastic path (no _Lt_from_F): exercises the generic UL
+        # box -> dS/dE -> Lie conversion
+        material = fd.constitutivelaw.Simcoon("ELISO", [8.7, 0.49, 1e-5], name="law")
+    else:  # EPICP: evolving elastoplastic box tangent, loaded beyond yield
+        material = fd.constitutivelaw.Simcoon("EPICP", EPICP_PROPS, name="law")
+        # FD around a converged state measures the derivative of the
+        # algorithmic (return-mapping) update: compare against the
+        # Simo-Hughes algorithmic tangent, not the continuum one.
+        material.tangent_mode = 2
+    wf = fd.weakform.StressEquilibrium(material, nlgeom=nlgeom)
+    wf.geometric_stiffness = True
+    if corate is not None:
+        wf.corate = corate
+    assembly = fd.Assembly.create(wf, mesh, name="asm")
+
+    pb = fd.problem.NonLinear("asm")
+    pb.set_nr_criterion("Displacement", err0=1.0, tol=1e-10, max_subiter=30)
+
+    bottom = mesh.find_nodes("Z", mesh.bounding_box.zmin)
+    top = mesh.find_nodes("Z", mesh.bounding_box.zmax)
+    pb.bc.add("Dirichlet", bottom, "DispZ", 0)
+    pb.bc.add("Dirichlet", [0], "Disp", 0)
+    pb.bc.add("Dirichlet", top, "DispZ", STRETCH)
+
+    if law == "EPICP":
+        # Plasticity: solve ONE increment and do NOT commit it (no set_start),
+        # so sv_start stays virgin and the FD point sits DEEP in the plastic
+        # branch (de = 10%). Committing would leave the FD state exactly on
+        # the yield surface (de = 0): a central difference then straddles the
+        # elastic/plastic kink and measures ~(C_e + C_ep)/2, not the tangent.
+        pb.initialize()
+        pb.tmax = 1.0
+        pb.dtime = 1.0
+        pb.set_start()
+        pb.time = 0.0
+        convergence, _, _ = pb.solve_time_increment()
+        assert convergence, "EPICP single increment did not converge"
+    else:
+        pb.nlsolve(dt=0.2, tmax=1.0, update_dt=True, print_info=0)
+
+    n_nodes = mesh.n_nodes
+    blocked = {0, n_nodes, 2 * n_nodes}
+    for n in np.concatenate([bottom, top]):
+        blocked.add(int(n) + 2 * n_nodes)
+    free = np.array([i for i in range(3 * n_nodes) if i not in blocked])
+    return _directional_fd_error(pb, assembly, free)
+
+
+_CASES = [
+    # (law, corate). NEOHC's Lt is baked by inverting the transport, so it is
+    # exact with any simcoon and needs no capability gate.
+    pytest.param("NEOHC", "log", id="NEOHC-log"),
+    pytest.param("ELISO", "log", marks=requires_exact_transport, id="ELISO-log"),
+    pytest.param("ELISO", "log_r", marks=requires_exact_transport, id="ELISO-logR"),
+    pytest.param("EPICP", "log", marks=requires_exact_transport, id="EPICP-log"),
+    pytest.param("EPICP", "log_r", marks=requires_exact_transport, id="EPICP-logR"),
+]
+
+
+@pytest.mark.parametrize("law, corate", _CASES)
+@pytest.mark.parametrize("nlgeom", ["TL", "UL"])
+def test_finite_strain_tangent_is_fd_consistent(nlgeom, law, corate):
+    err = _fd_tangent_error(nlgeom, law, corate)
+    assert err < 1e-6, (
+        f"{law} {nlgeom} corate={corate} global tangent inconsistent with FD "
+        f"(rel error {err:.3e}): check the 3D geometric stiffness operator "
+        "and the UL tangent conversion (box -> dS/dE -> Lie)"
+    )
+
+
+def _fd_history_tangent_error(gamma1, corate, n_inc=4, dgamma=0.05):
+    """FD consistency WITH committed plastic history (rotating simple shear).
+
+    EPICP cube, UL: n_inc committed increments to gamma1 (set_start after
+    each: stress rotated, statev stored), then ONE more increment solved
+    WITHOUT set_start; central FD of the assembled vector around its
+    converged endpoint, exactly like _fd_tangent_error.
+    """
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("3D")
+    # nx=3: with both z-faces fully driven (shear), the mid-layer nodes are
+    # the free dofs the FD probes (nx=2 would leave none).
+    mesh = fd.mesh.box_mesh(nx=3, ny=3, nz=3, elm_type="hex8", name="box")
+
+    material = fd.constitutivelaw.Simcoon("EPICP", EPICP_PROPS, name="law")
+    material.tangent_mode = 2
+    wf = fd.weakform.StressEquilibrium(material, nlgeom="UL")
+    wf.geometric_stiffness = True
+    wf.corate = corate
+    assembly = fd.Assembly.create(wf, mesh, name="asm")
+
+    pb = fd.problem.NonLinear("asm")
+    pb.set_nr_criterion("Displacement", err0=1.0, tol=1e-10, max_subiter=30)
+
+    bottom = mesh.find_nodes("Z", mesh.bounding_box.zmin)
+    top = mesh.find_nodes("Z", mesh.bounding_box.zmax)
+    zmax = mesh.bounding_box.zmax
+    gamma_total = gamma1 + dgamma
+    pb.bc.add("Dirichlet", bottom, "Disp", 0)
+    pb.bc.add("Dirichlet", top, "DispX", gamma_total * zmax)
+    pb.bc.add("Dirichlet", top, "DispY", 0)
+    pb.bc.add("Dirichlet", top, "DispZ", 0)
+
+    pb.initialize()
+    pb.tmax = 1.0
+    t1 = gamma1 / gamma_total
+    pb.dtime = t1 / n_inc
+    pb.set_start()
+    pb.time = 0.0
+    for i in range(n_inc):
+        conv, _, _ = pb.solve_time_increment()
+        assert conv, f"committed increment {i + 1} did not converge"
+        pb.set_start()
+        pb.time = (i + 1) * pb.dtime
+
+    pb.dtime = 1.0 - t1
+    conv, _, _ = pb.solve_time_increment()
+    assert conv, "final uncommitted increment did not converge"
+
+    n_nodes = mesh.n_nodes
+    blocked = set()
+    for n in np.concatenate([bottom, top]):
+        for r in range(3):
+            blocked.add(int(n) + r * n_nodes)
+    free = np.array([i for i in range(3 * n_nodes) if i not in blocked])
+    return _directional_fd_error(pb, assembly, free)
+
+
+@requires_exact_history_transport
+def test_finite_strain_tangent_with_plastic_history():
+    # corate log_R only: the XBM ("log") frame increment is not exactly
+    # equivariant, leaving a documented O(||EP|| * dtheta) residual (see the
+    # module docstring KNOWN LIMIT) -- log_R is the exact-transport corate.
+    err = _fd_history_tangent_error(0.2, "log_r")
+    assert err < 1e-6, (
+        f"UL EPICP corate=log_r with committed plastic history: global "
+        f"tangent inconsistent with FD (rel error {err:.3e}): check the "
+        "polar conjugation in simcoon's exact transport and the log_R "
+        "frame increment DR = R1 R0^T"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_line_search_bc_contract.py
+++ b/tests/test_line_search_bc_contract.py
@@ -1,0 +1,53 @@
+"""A step-size callback must not damp a pending Dirichlet increment.
+
+Scaling the elastic prediction by alpha defers the remaining `1 - alpha` of
+the Dirichlet increment to the following iterations, and convergence is only
+declared once nothing is left to apply (`_xbc_is_applied`). A callback that
+never returns exactly 1 therefore leaves the increment unfinished forever and
+the solver keeps cutting the time step down to `dt_min`. The built-in line
+search guarantees this by returning 1 while `_Xbc` is non-zero; a custom
+callback has to do the same (see `NonLinear.add_line_search`).
+"""
+
+import numpy as np
+import pytest
+
+import fedoo as fd
+from fedoo.problem.line_search import line_search
+
+
+def _problem_with_pending_dirichlet():
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("2Dplane")
+    mesh = fd.mesh.rectangle_mesh(3, 3, 0, 1, 0, 1, elm_type="quad4", name="sq")
+    material = fd.constitutivelaw.ElasticIsotrop(1e3, 0.3, name="law")
+    weakform = fd.weakform.StressEquilibrium(material, name="wf")
+    assembly = fd.Assembly.create(weakform, mesh, name="asm")
+    problem = fd.problem.NonLinear(assembly)
+    problem.add_line_search()
+    problem.bc.add("Dirichlet", mesh.node_sets["bottom"], "Disp", 0)
+    problem.bc.add("Dirichlet", mesh.node_sets["top"], "Disp", [0.0, 0.1])
+    problem.dtime = 1.0
+    problem.initialize()
+    problem.apply_boundary_conditions(1.0, 0.0)
+    return problem
+
+
+def test_built_in_line_search_yields_while_a_dirichlet_increment_is_pending():
+    problem = _problem_with_pending_dirichlet()
+    assert np.any(problem._Xbc)  # a prescribed increment is waiting
+    assert not problem._xbc_is_applied()
+
+    assert line_search(problem, np.zeros(problem.n_dof)) == 1
+
+
+def test_displacement_control_reaches_the_prescribed_value():
+    """End to end: the built-in line search never strands the increment."""
+    problem = _problem_with_pending_dirichlet()
+    problem.nlsolve(dt=1.0, tmax=1.0, update_dt=False, print_info=0)
+    top = fd.Mesh["sq"].node_sets["top"]
+    assert abs(problem.get_disp()[1, top].max() - 0.1) < 1e-10
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_line_search_mode.py
+++ b/tests/test_line_search_mode.py
@@ -1,0 +1,56 @@
+"""Guard the line-search policy defaults of NonLinear.add_line_search.
+
+The default must both throttle penalty-contact / plastic overshoot (a
+validity-only default broke examples/03-advanced/tube_compression.py) and
+let soft-mode force-control steps through (a residual-only default breaks
+neohookean_cantilever_force.py): that is the "natural" mode.
+"""
+
+import pytest
+
+import fedoo as fd
+from fedoo.problem.line_search import line_search
+
+
+def _make_problem():
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("2D")
+    mesh = fd.mesh.rectangle_mesh(2, 2, 0, 1, 0, 1, elm_type="quad4", name="sq")
+    mat = fd.constitutivelaw.ElasticIsotrop(1e3, 0.3, name="law")
+    wf = fd.weakform.StressEquilibrium(mat, name="wf")
+    asm = fd.Assembly.create(wf, mesh, name="asm")
+    return fd.problem.NonLinear(asm)
+
+
+@pytest.mark.parametrize(
+    "kwargs, mode, method",
+    [
+        ({}, "natural", "Quadratic"),  # default
+        ({"mode": "minimize", "method": "Residual"}, "minimize", "Residual"),
+        ({"mode": "safeguard"}, "safeguard", "Quadratic"),
+    ],
+)
+def test_add_line_search_records_mode(kwargs, mode, method):
+    pb = _make_problem()
+    pb.add_line_search(**kwargs)
+    assert pb.nr_parameters["ls_mode"] == mode
+    assert pb.nr_parameters["ls_method"] == method
+    assert pb._step_size_callback is line_search
+
+
+def test_mode_can_be_set_through_nr_criterion():
+    pb = _make_problem()
+    pb.add_line_search()
+    pb.set_nr_criterion("Displacement", ls_mode="safeguard", ls_max_iter=8)
+    assert pb.nr_parameters["ls_mode"] == "safeguard"
+    assert pb.nr_parameters["ls_max_iter"] == 8
+
+
+def test_invalid_mode_raises():
+    pb = _make_problem()
+    with pytest.raises(ValueError):
+        pb.add_line_search(mode="foo")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_time_integrator_restart_state.py
+++ b/tests/test_time_integrator_restart_state.py
@@ -1,0 +1,68 @@
+"""A set_start without a solved increment must not consume a time step.
+
+`nlsolve` resets the clock (`time = t0`), so a second stage -- a restart
+from the current state with a new loading -- enters its loop with an empty
+increment (`_dU == 0`) and calls `set_start` again. The Newmark recurrence
+is NOT the identity for a zero displacement increment:
+
+    v <- v (1 - gamma/beta) + dt (1 - gamma/2beta) a
+
+which is exactly ``-v`` for the standard parameters (beta=1/4, gamma=1/2).
+Velocity and acceleration were therefore corrupted at the start of every
+stage after the first, for the `fd.time` integrators and for the legacy
+`ImplicitDynamic` weak form alike.
+"""
+
+import numpy as np
+import pytest
+
+import fedoo as fd
+
+
+def _dynamic_problem(legacy=False):
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("2Dplane")
+    mesh = fd.mesh.rectangle_mesh(6, 3, 0, 3, 0, 1, elm_type="quad4")
+    material = fd.constitutivelaw.ElasticIsotrop(2e5, 0.3)
+    material.set_density(7800e-9)
+    if legacy:
+        weakform = fd.weakform.ImplicitDynamic(material, 0.01)
+        assembly = fd.Assembly.create(weakform, mesh)
+        problem = fd.problem.NonLinear(assembly)
+    else:
+        assembly = fd.Assembly.create(fd.weakform.StressEquilibrium(material), mesh)
+        problem = fd.problem.NonLinear(assembly)
+        problem.set_time_integrator(fd.time.SECOND_ORDER, fd.time.Newmark())
+    problem.bc.add("Dirichlet", mesh.find_nodes("X", 0), "Disp", 0)
+    problem.bc.add(
+        "Neumann",
+        mesh.find_nodes("X", 3),
+        "DispY",
+        -0.5,
+        time_func=lambda t_fact: 1.0,
+    )
+    problem.nlsolve(dt=0.01, tmax=0.1, update_dt=False, print_info=0)
+    return problem, assembly
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_empty_set_start_keeps_the_dynamic_state(legacy):
+    problem, assembly = _dynamic_problem(legacy)
+    velocity = np.array(assembly.sv["Velocity"], copy=True)
+    acceleration = np.array(assembly.sv["Acceleration"], copy=True)
+    assert np.abs(velocity).max() > 0  # the state is not trivially preserved
+
+    problem.set_start()  # what the first loop turn of a new stage does
+
+    assert np.allclose(assembly.sv["Velocity"], velocity, rtol=0, atol=0)
+    assert np.allclose(assembly.sv["Acceleration"], acceleration, rtol=0, atol=0)
+
+
+def test_increment_solved_flag_tracks_the_increment():
+    problem, _ = _dynamic_problem()
+    problem.set_start()
+    assert problem._increment_solved is False  # nothing left to commit
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_time_integrator_stability_warning.py
+++ b/tests/test_time_integrator_stability_warning.py
@@ -1,0 +1,81 @@
+"""Stability guards of the implicit second-order time integrators.
+
+A Newmark/generalized-alpha pair violating the unconditional (A-) stability
+conditions (gamma >= 1/2 - alpha_m + alpha_f, beta >= gamma/2,
+alpha_m <= alpha_f <= 1/2) is only conditionally stable: with FE meshes
+(omega_max*dt >> 1) the high-frequency modes grow geometrically and the
+solve collapses after a few tens of increments, regardless of dt or load —
+a failure that masquerades as Newton divergence / element inversion (this
+cost a full day of root-causing on the force-controlled RigidTie benchmark:
+beta=0.25 with gamma=0.6 died at ~20-26 committed increments at any dt).
+Both entry points must warn on violating pairs and stay silent on valid
+ones.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import fedoo as fd
+
+
+def _material():
+    fd.ModelingSpace("3D")
+    mat = fd.constitutivelaw.ElasticIsotrop(1e6, 0.3)
+    mat.set_density(1000.0)
+    return mat
+
+
+def _n_stability_warnings(record):
+    return sum("CONDITIONALLY stable" in str(w.message) for w in record)
+
+
+def test_implicit_dynamic_warns_on_conditionally_stable_pair():
+    mat = _material()
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        fd.weakform.ImplicitDynamic(mat, 1000.0, beta=0.25, gamma=0.6)
+    assert _n_stability_warnings(rec) == 1
+
+
+def test_implicit_dynamic_silent_on_stable_pairs():
+    mat = _material()
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        fd.weakform.ImplicitDynamic(mat, 1000.0)  # default beta=0.25 gamma=0.5
+        fd.weakform.ImplicitDynamic(mat, 1000.0, beta=0.3025, gamma=0.6)
+        fd.weakform.ImplicitDynamic(mat, 1000.0, beta=0.30, gamma=0.6)
+    assert _n_stability_warnings(rec) == 0
+
+
+def test_generalized_alpha_warns_on_conditionally_stable_pairs():
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        fd.time.Newmark(beta=0.25, gamma=0.6)  # beta < gamma/2
+    assert _n_stability_warnings(rec) == 1
+
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        fd.time.Newmark(beta=0.25, gamma=0.4)  # gamma < 1/2
+    assert _n_stability_warnings(rec) == 1
+
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        fd.time.GeneralizedAlpha(alpha_m=0.3, alpha_f=0.1)  # alpha_m > alpha_f
+    assert _n_stability_warnings(rec) == 1
+
+
+def test_generalized_alpha_silent_on_stable_sets():
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        fd.time.Newmark()  # defaults
+        fd.time.Newmark(beta=0.3025, gamma=0.6)
+        fd.time.GeneralizedAlpha()  # Newmark trapezoidal
+        # Chung-Hulbert defaults from the alphas (gamma and beta computed)
+        fd.time.GeneralizedAlpha(alpha_m=0.2, alpha_f=0.4)
+    assert _n_stability_warnings(rec) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_transient_prediction_tangent.py
+++ b/tests/test_transient_prediction_tangent.py
@@ -1,0 +1,61 @@
+"""The transient elastic prediction must not reuse a tangent of another dt.
+
+A `fd.time` tangent carries the Newmark inertia term `1/(beta dt^2)`, so
+reusing the previous increment's matrix after a time-step change leaves it
+wrong by `(dt_prev/dt)^2` -- a factor 16 after the standard x0.25 cut, i.e.
+exactly when the solver is already struggling. Static problems must keep
+reusing the matrix: the "time integrators compiled" flag is True even with
+none attached, so the refresh is gated on an actually attached integrator.
+"""
+
+import pytest
+
+import fedoo as fd
+
+
+def _problem(with_integrator, density=100.0):
+    fd.Assembly.delete_memory()
+    fd.ModelingSpace("2Dplane")
+    mesh = fd.mesh.rectangle_mesh(4, 2, 0, 4, 0, 1, elm_type="quad4", name="beam")
+    material = fd.constitutivelaw.ElasticIsotrop(2e5, 0.3, name="law")
+    material.set_density(density)
+    assembly = fd.Assembly.create(fd.weakform.StressEquilibrium(material), mesh)
+    problem = fd.problem.NonLinear(assembly)
+    if with_integrator:
+        problem.set_time_integrator(fd.time.SECOND_ORDER, fd.time.Newmark())
+    problem.bc.add("Dirichlet", mesh.find_nodes("X", 0), "Disp", 0)
+    problem.bc.add("Neumann", mesh.find_nodes("X", 4), "DispY", -1.0)
+    problem.nlsolve(dt=0.01, tmax=0.02, update_dt=False, print_info=0)
+    return problem, assembly
+
+
+def _predict_after_step_change(problem, new_dt):
+    """Run one elastic prediction with a changed dt; return the tangent used."""
+    problem._dtime_prev = problem.dtime
+    problem.dtime = new_dt
+    problem.set_start()
+    stale = problem.get_A()
+    problem.elastic_prediction()
+    return stale, problem.get_A()
+
+
+def test_transient_tangent_is_refreshed_after_a_step_change():
+    problem, assembly = _problem(with_integrator=True)
+    stale, used = _predict_after_step_change(problem, problem.dtime * 0.25)
+    # the tangent actually used is the one re-assembled at the new time step
+    assert used is assembly.current.get_global_matrix()
+    assert used is not stale
+    assert abs(used - stale).max() > 0
+    # the inertia term scales as 1/dt^2, so a x0.25 cut stiffens the matrix
+    assert abs(used).max() > 4 * abs(stale).max()
+
+
+def test_static_tangent_is_still_reused_after_a_step_change():
+    problem, _ = _problem(with_integrator=False)
+    assert not problem.time_integrators
+    stale, used = _predict_after_step_change(problem, problem.dtime * 0.25)
+    assert used is stale
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_weakform_factory_types.py
+++ b/tests/test_weakform_factory_types.py
@@ -72,9 +72,11 @@ def test_composite_weakforms_preserve_child_assembly_options():
 
     implicit = fd.weakform.ImplicitDynamic(material, density=1.0)
     assert implicit.assembly_options is None
+    # assume_sym is left unset at construction on both children (same
+    # assembly grouping key -> merged assembly); it is decided at initialize
+    # by the stiffness weakform (True except nlgeom='UL').
     assert all(
-        wf.assembly_options.get("assume_sym", "quad4", False)
-        for wf in implicit.list_weakform
+        wf.assembly_options.get("assume_sym") is None for wf in implicit.list_weakform
     )
 
     reduced_integration = fd.weakform.StressEquilibriumRI(material)
@@ -114,6 +116,9 @@ def test_composite_assembly_options_are_applied_by_assembly_create():
     implicit_assembly = fd.Assembly.create(implicit, mesh)
     assert isinstance(implicit_assembly, Assembly)
     assert implicit_assembly.n_elm_gp == 4
+    # assume_sym is decided at initialize (True here: no nlgeom)
+    pb = fd.problem.Linear(implicit_assembly)
+    pb.initialize()
     assert implicit_assembly.assume_sym is True
     assert implicit_assembly.mat_lumping == [False, False]
 


### PR DESCRIPTION
Bump the Simcoon requirement to >=2.0.0b1, simplify Conda packaging by removing conda_build_config and using python-mumps, and update the installation documentation. Improve PyVistaQt import handling for Qt binding runtime errors.
Improve dynamic integration reliability: add a clear error for zero lumped-mass diagonals on free DOFs, complete the velocity-Verlet/central-difference end-step acceleration update, reset dynamic initialization correctly in Linear.reset(), and add explicit energy-conservation tests.
Strengthen nonlinear robustness with natural, residual-minimizing, and kinematic-safeguard line-search modes. Add optional Dirichlet-increment scaling, reject increments when no kinematically valid step exists, improve factorization reuse and invalidation, fix adaptive-stiffness and transient-tangent updates, and remove the unused eigenvalue-shift strategy. Energy-based artificial damping now decreases more conservatively near unstable configurations.
Finally, clean up the problem APIs and documentation: consistently place name last in high-level signatures, improve line-search documentation, and simplify the documentation navigation to emphasize sections while keeping generated API objects in the main content.